### PR TITLE
refactor: create HTTP client abstraction layer

### DIFF
--- a/cmd/process/listProcesses.go
+++ b/cmd/process/listProcesses.go
@@ -1,14 +1,8 @@
 package process
 
 import (
-	"encoding/json"
 	"fmt"
 	"ftsctl/cmd/utils"
-	"io"
-	"log/slog"
-	"net/http"
-	"os"
-	"time"
 
 	"github.com/spf13/cobra"
 )
@@ -18,41 +12,11 @@ var listProcessesCmd = &cobra.Command{
 	Short: "List all transfer process statuses",
 	Long:  `Lists all available transfer process statuses.`,
 	Run: func(cmdCobra *cobra.Command, args []string) {
-		apiUrl := utils.BuildApiUrl("/api/v2/process/statuses")
-
-		client := &http.Client{}
-		req, err := http.NewRequest("GET", apiUrl, nil)
-		if err != nil {
-			slog.Error("Error creating the request", "error", err)
-			os.Exit(1)
-		}
-
-		resp, err := client.Do(req)
-		if err != nil {
-			slog.Error("Error sending the request", "error", err)
-			os.Exit(1)
-		}
-		defer func() {
-			if err := resp.Body.Close(); err != nil {
-				slog.Warn("Warning: failed to close response body", "error", err)
-			}
-		}()
-
-		if resp.StatusCode != http.StatusOK {
-			slog.Error("Unexpected status code", "status", resp.StatusCode)
-			os.Exit(1)
-		}
-
-		body, err := io.ReadAll(resp.Body)
-		if err != nil {
-			slog.Error("Error reading the response", "error", err)
-			os.Exit(1)
-		}
-
+		client := utils.NewClient()
 		var processes []utils.Process
-		if err := json.Unmarshal(body, &processes); err != nil {
-			slog.Error("Error parsing JSON", "error", err)
-			os.Exit(1)
+
+		if err := client.GetJSON("/api/v2/process/statuses", &processes); utils.LogHTTPError(err, "fetch process statuses") {
+			return
 		}
 
 		utils.DivdlnL()
@@ -60,19 +24,7 @@ var listProcessesCmd = &cobra.Command{
 		utils.DivdlnL()
 
 		for _, p := range processes {
-			fmt.Printf("ProcessID: %s\n", p.ProcessID)
-			fmt.Printf("Phase: %s\n", p.Phase)
-			fmt.Printf("CreatedAt: %s\n", p.CreatedAt.ToTime().Local().Format(time.RFC1123))
-			if p.FinishedAt != nil {
-				fmt.Printf("FinishedAt: %s\n", p.FinishedAt.ToTime().Local().Format(time.RFC1123))
-			} else {
-				fmt.Println("FinishedAt: The process is still running.")
-			}
-			fmt.Printf("TotalPatients: %d\n", p.TotalPatients)
-			fmt.Printf("TotalBundles: %d\n", p.TotalBundles)
-			fmt.Printf("DeidentifiedBundles: %d\n", p.DeidentifiedBundles)
-			fmt.Printf("SentBundles: %d\n", p.SentBundles)
-			fmt.Printf("SkippedBundles: %d\n", p.SkippedBundles)
+			utils.PrintProcessStatus(p)
 			utils.DivdlnS()
 		}
 	},

--- a/cmd/process/processStatus.go
+++ b/cmd/process/processStatus.go
@@ -1,14 +1,8 @@
 package process
 
 import (
-	"encoding/json"
 	"fmt"
 	"ftsctl/cmd/utils"
-	"io"
-	"log/slog"
-	"net/http"
-	"os"
-	"time"
 
 	"github.com/spf13/cobra"
 )
@@ -20,7 +14,6 @@ var StatusCmd = &cobra.Command{
 	Short: "Show process status",
 	Long:  `Shows the process status of the selected process ID`,
 	Run: func(cmd *cobra.Command, args []string) {
-
 		if !cmd.Flags().Changed("processId") {
 			utils.DivdlnL()
 			fmt.Printf("Warning: No --processId (-i) specified.\n\nPlease set the flag to retrieve the status of a process.\n")
@@ -28,62 +21,17 @@ var StatusCmd = &cobra.Command{
 			return
 		}
 
-		apiUrl := utils.BuildApiUrl("/api/v2/process/status/" + processId)
-		slog.Debug("Making API request", "url", apiUrl)
-		client := &http.Client{}
-		req, err := http.NewRequest("GET", apiUrl, nil)
+		client := utils.NewClient()
+		var prcss utils.Process
 
-		if err != nil {
-			slog.Error("Error creating the request", "error", err)
-			os.Exit(1)
-		}
-
-		resp, err := client.Do(req)
-		if err != nil {
-			slog.Error("Error sending the request", "error", err)
-			os.Exit(1)
-		}
-
-		defer func() {
-			if err := resp.Body.Close(); err != nil {
-				slog.Warn("Error closing response body", "error", err)
-			}
-		}()
-
-		if resp.StatusCode != http.StatusOK {
-			slog.Error("Unexpected status code", "status", resp.StatusCode)
-			os.Exit(1)
-		}
-
-		body, err := io.ReadAll(resp.Body)
-		if err != nil {
-			slog.Error("Error reading the response", "error", err)
-			os.Exit(1)
-		}
-
-		prcss := utils.Process{}
-		err = json.Unmarshal(body, &prcss)
-		if err != nil {
-			slog.Error("Error unmarshalling response", "error", err)
-			os.Exit(1)
+		if err := client.GetJSON("/api/v2/process/status/"+processId, &prcss); utils.LogHTTPError(err, "fetch process status") {
+			return
 		}
 
 		utils.DivdlnL()
 		fmt.Printf("Representation of the Process with the ProcessID: %s \n", processId)
 		utils.DivdlnL()
-		fmt.Printf("ProcessID: %s\n", prcss.ProcessID)
-		fmt.Printf("Phase: %s\n", prcss.Phase)
-		fmt.Printf("CreatedAt: %s\n", prcss.CreatedAt.ToTime().Local().Format(time.RFC1123))
-		if prcss.FinishedAt != nil {
-			fmt.Printf("FinishedAt: %s\n", prcss.FinishedAt.ToTime().Local().Format(time.RFC1123))
-		} else {
-			fmt.Println("FinishedAt: The process is still running")
-		}
-		fmt.Printf("TotalPatients: %d\n", prcss.TotalPatients)
-		fmt.Printf("TotalBundles: %d\n", prcss.TotalBundles)
-		fmt.Printf("DeidentifiedBundles: %d\n", prcss.DeidentifiedBundles)
-		fmt.Printf("SentBundles: %d\n", prcss.SentBundles)
-		fmt.Printf("SkippedBundles: %d\n", prcss.SkippedBundles)
+		utils.PrintProcessStatus(prcss)
 		utils.DivdlnS()
 	},
 }

--- a/cmd/project/listProjects.go
+++ b/cmd/project/listProjects.go
@@ -1,11 +1,7 @@
 package project
 
 import (
-	"encoding/json"
 	"fmt"
-	"io"
-	"log/slog"
-	"net/http"
 
 	"ftsctl/cmd/utils"
 	"github.com/spf13/cobra"
@@ -17,58 +13,18 @@ var ListProjectsCmd = &cobra.Command{
 	Long:  `List of all available projects from the API.`,
 
 	Run: func(cmd *cobra.Command, args []string) {
+		client := utils.NewClient()
+		var projects []string
 
-		// Generate API URL
-		apiUrl := utils.BuildApiUrl("/api/v2/projects")
-
-		// Create HTTP client
-		client := &http.Client{}
-
-		// Create a new HTTP GET request
-		req, err := http.NewRequest("GET", apiUrl, nil)
-		if err != nil {
-			slog.Error("Error creating the request", "error", err)
-			return
-		}
-		slog.Debug("Sending request", "url", req.URL.String())
-
-		// Send the request
-		resp, err := client.Do(req)
-		if err != nil {
-			slog.Error("Error sending the request", "error", err)
-			return
-		}
-
-		defer func() {
-			if err := resp.Body.Close(); err != nil {
-				slog.Warn("Error closing response body", "error", err)
-			}
-		}()
-
-		// Check the status code (StatusOk = 200)
-		if resp.StatusCode != http.StatusOK {
-			slog.Error("Unexpected status code", "status", resp.StatusCode)
-			return
-		}
-
-		body, err := io.ReadAll(resp.Body)
-		if err != nil {
-			slog.Error("Error reading the response", "error", err)
-			return
-		}
-
-		var sliceProjects []string
-		err = json.Unmarshal(body, &sliceProjects)
-		if err != nil {
-			slog.Error("Unmarshal error", "error", err)
+		if err := client.GetJSON("/api/v2/projects", &projects); utils.LogHTTPError(err, "fetch projects") {
 			return
 		}
 
 		utils.DivdlnL()
 		fmt.Println("List of all available projects:")
 		utils.DivdlnL()
-		for i, sliceProject := range sliceProjects {
-			fmt.Printf("%d. %s\n", i+1, sliceProject)
+		for i, project := range projects {
+			fmt.Printf("%d. %s\n", i+1, project)
 		}
 		utils.DivdlnS()
 	},

--- a/cmd/project/projectConfig.go
+++ b/cmd/project/projectConfig.go
@@ -1,11 +1,7 @@
 package project
 
 import (
-	"encoding/json"
 	"fmt"
-	"io"
-	"log/slog"
-	"net/http"
 
 	"ftsctl/cmd/utils"
 	"github.com/spf13/cobra"
@@ -86,7 +82,6 @@ var ConfigCmd = &cobra.Command{
 	Short: "Project configuration",
 	Long:  `Shows the project configuration of the selected project.`,
 	Run: func(cmd *cobra.Command, args []string) {
-
 		if !cmd.Flags().Changed("projectName") {
 			utils.DivdlnL()
 			fmt.Printf("Warning: No --projectName (-n) specified.\n\nPlease set the Flag to retrieve the Project Configuration of a Project.\n")
@@ -94,42 +89,10 @@ var ConfigCmd = &cobra.Command{
 			return
 		}
 
-		apiUrl := utils.BuildApiUrl("/api/v2/projects/" + PrjName)
-		client := &http.Client{}
-		req, err := http.NewRequest("GET", apiUrl, nil)
+		client := utils.NewClient()
+		var pConfig Config
 
-		if err != nil {
-			slog.Error("Error creating the request", "error", err)
-			return
-		}
-
-		resp, err := client.Do(req)
-		if err != nil {
-			slog.Error("Error sending the request", "error", err)
-			return
-		}
-
-		defer func() {
-			if err := resp.Body.Close(); err != nil {
-				slog.Warn("Error closing response body", "error", err)
-			}
-		}()
-
-		if resp.StatusCode != http.StatusOK {
-			slog.Error("Unexpected status code", "status", resp.StatusCode)
-			return
-		}
-
-		body, err := io.ReadAll(resp.Body)
-		if err != nil {
-			slog.Error("Error reading the response", "error", err)
-			return
-		}
-
-		pConfig := Config{}
-		err = json.Unmarshal(body, &pConfig)
-		if err != nil {
-			slog.Error("Error decoding JSON", "error", err)
+		if err := client.GetJSON("/api/v2/projects/"+PrjName, &pConfig); utils.LogHTTPError(err, "fetch project config") {
 			return
 		}
 

--- a/cmd/startTransfer_test.go
+++ b/cmd/startTransfer_test.go
@@ -13,32 +13,32 @@ func TestStartTransferCommandExists(t *testing.T) {
 	}
 }
 
-func TestRequestPayloadMarshaling_OmitEmpty(t *testing.T) {
+func TestIDsPayloadMarshaling(t *testing.T) {
 	tests := []struct {
 		name     string
-		payload  transfer.RequestPayload
+		ids      []string
 		expected string
 	}{
 		{
 			name:     "Nil IDs",
-			payload:  transfer.RequestPayload{IDs: nil},
-			expected: `{}`,
+			ids:      nil,
+			expected: `null`,
 		},
 		{
 			name:     "Empty slice IDs",
-			payload:  transfer.RequestPayload{IDs: []string{}},
-			expected: `{}`,
+			ids:      []string{},
+			expected: `[]`,
 		},
 		{
 			name:     "With IDs",
-			payload:  transfer.RequestPayload{IDs: []string{"id1", "id2"}},
-			expected: `{"ids":["id1","id2"]}`,
+			ids:      []string{"id1", "id2"},
+			expected: `["id1","id2"]`,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result, err := json.Marshal(tt.payload)
+			result, err := json.Marshal(tt.ids)
 			if err != nil {
 				t.Fatalf("unexpected error while marshaling: %v", err)
 			}

--- a/cmd/transfer/startTransfer.go
+++ b/cmd/transfer/startTransfer.go
@@ -1,28 +1,19 @@
 package transfer
 
 import (
-	"bytes"
-	"encoding/json"
 	"fmt"
 	"ftsctl/cmd/utils"
-	"github.com/spf13/cobra"
-	"io"
 	"log/slog"
-	"net/http"
-	"os"
 	"strings"
-)
 
-// RequestPayload defines the structure for the optional ID list
-type RequestPayload struct {
-	IDs []string `json:"ids,omitempty"`
-}
+	"github.com/spf13/cobra"
+)
 
 var startTransferCmd = &cobra.Command{
 	Use:   "start",
 	Short: "Start a transfer process",
 	Long: `Start a transfer of patients with IDs provided in the request
-body, or if none are provided, start a transfer of all consented 
+body, or if none are provided, start a transfer of all consented
 patients for the specified project.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		projectName, _ := cmd.Flags().GetString("projectName")
@@ -38,57 +29,29 @@ patients for the specified project.`,
 			ids = strings.Split(idsStr, ",")
 		}
 
-		apiUrl := utils.BuildApiUrl(fmt.Sprintf("/api/v2/process/%s/start", projectName))
+		client := utils.NewClient()
+		endpoint := fmt.Sprintf("/api/v2/process/%s/start", projectName)
 
-		var resp *http.Response
-		var err error
-
+		var body interface{}
 		if len(ids) > 0 {
-			jsonData, err := json.Marshal(ids)
-			if err != nil {
-				slog.Error("Error creating JSON payload", "error", err)
-				os.Exit(1)
-			}
-			slog.Debug("JSON payload created", "payload", string(jsonData))
-
-			resp, err = http.Post(apiUrl, "application/json", bytes.NewBuffer(jsonData))
-		} else {
-			resp, err = http.Post(apiUrl, "application/json", nil)
+			body = ids
 		}
 
-		if err != nil {
-			slog.Error("Error sending request", "error", err)
-			os.Exit(1)
+		if err := client.PostJSON(endpoint, body, nil); utils.PrintHTTPError(err) {
+			return
 		}
-		defer func() {
-			if cerr := resp.Body.Close(); cerr != nil {
-				slog.Warn("Error closing response body", "error", cerr)
-			}
-		}()
 
 		utils.DivdlnL()
-
-		if resp.StatusCode == http.StatusOK || resp.StatusCode == http.StatusAccepted {
-			if len(ids) > 0 {
-				fmt.Printf("Transfer of project '%s' has started with the following patient IDs:\n", projectName)
-				for _, id := range ids {
-					fmt.Printf("   - %s\n", id)
-				}
-			} else {
-				fmt.Printf("Transfer of project '%s' has started for all consented patients.\n", projectName)
+		if len(ids) > 0 {
+			fmt.Printf("Transfer of project '%s' has started with the following patient IDs:\n", projectName)
+			for _, id := range ids {
+				fmt.Printf("   - %s\n", id)
 			}
-			slog.Debug("Transfer request completed", "url", apiUrl, "status", resp.Status)
 		} else {
-			fmt.Printf("Request failed! Response Status: %s\n", resp.Status)
-
-			bodyBytes, err := io.ReadAll(resp.Body)
-			if err != nil {
-				slog.Error("Error reading response body", "error", err)
-			} else {
-				fmt.Printf("Server response body:\n%s\n", string(bodyBytes))
-			}
-			utils.DivdlnL()
+			fmt.Printf("Transfer of project '%s' has started for all consented patients.\n", projectName)
 		}
+		slog.Debug("Transfer request completed", "project", projectName)
+		utils.DivdlnS()
 	},
 }
 

--- a/cmd/utils/format.go
+++ b/cmd/utils/format.go
@@ -1,6 +1,10 @@
 package utils
 
-import "fmt"
+import (
+	"fmt"
+	"log/slog"
+	"time"
+)
 
 // Dividing Lines
 
@@ -47,4 +51,55 @@ func GenerateLogoV2() string {
 `
 
 	return logo
+}
+
+// PrintProcessStatus prints formatted status information for a Process.
+func PrintProcessStatus(p Process) {
+	fmt.Printf("ProcessID: %s\n", p.ProcessID)
+	fmt.Printf("Phase: %s\n", p.Phase)
+	fmt.Printf("CreatedAt: %s\n", p.CreatedAt.ToTime().Local().Format(time.RFC1123))
+	if p.FinishedAt != nil {
+		fmt.Printf("FinishedAt: %s\n", p.FinishedAt.ToTime().Local().Format(time.RFC1123))
+	} else {
+		fmt.Println("FinishedAt: The process is still running")
+	}
+	fmt.Printf("TotalPatients: %d\n", p.TotalPatients)
+	fmt.Printf("TotalBundles: %d\n", p.TotalBundles)
+	fmt.Printf("DeidentifiedBundles: %d\n", p.DeidentifiedBundles)
+	fmt.Printf("SentBundles: %d\n", p.SentBundles)
+	fmt.Printf("SkippedBundles: %d\n", p.SkippedBundles)
+}
+
+// LogHTTPError logs an HTTP error appropriately and returns true if an error was handled.
+func LogHTTPError(err error, context string) bool {
+	if err == nil {
+		return false
+	}
+
+	if httpErr, ok := IsHTTPError(err); ok {
+		slog.Error("API request failed", "context", context, "status", httpErr.Status, "details", httpErr.Body)
+	} else {
+		slog.Error("Request failed", "context", context, "error", err)
+	}
+	return true
+}
+
+// PrintHTTPError prints an HTTP error in a user-friendly format and returns true if an error was handled.
+// Use this when you want to display error details to the user (not just log them).
+func PrintHTTPError(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	DivdlnL()
+	if httpErr, ok := IsHTTPError(err); ok {
+		fmt.Printf("Request failed! Response Status: %s\n", httpErr.Status)
+		if httpErr.Body != "" {
+			fmt.Printf("Server response body:\n%s\n", httpErr.Body)
+		}
+	} else {
+		slog.Error("Request failed", "error", err)
+	}
+	DivdlnL()
+	return true
 }

--- a/cmd/utils/httpclient.go
+++ b/cmd/utils/httpclient.go
@@ -1,0 +1,207 @@
+package utils
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"math"
+	"net/http"
+	"time"
+)
+
+// HTTPClient defines the interface for HTTP operations.
+// This enables easy mocking in tests.
+type HTTPClient interface {
+	Do(req *http.Request) (*http.Response, error)
+}
+
+// Client provides high-level HTTP operations with retry logic.
+type Client struct {
+	httpClient  HTTPClient
+	maxRetries  int
+	baseBackoff time.Duration
+}
+
+// NewClient creates a new HTTP client with default configuration:
+// - 30 second timeout
+// - 3 retry attempts with exponential backoff (1s, 2s, 4s)
+func NewClient() *Client {
+	return &Client{
+		httpClient: &http.Client{
+			Timeout: 30 * time.Second,
+		},
+		maxRetries:  3,
+		baseBackoff: 1 * time.Second,
+	}
+}
+
+// NewClientWithHTTPClient creates a client with a custom HTTPClient.
+// Useful for testing with mocks.
+func NewClientWithHTTPClient(httpClient HTTPClient) *Client {
+	return &Client{
+		httpClient:  httpClient,
+		maxRetries:  3,
+		baseBackoff: 1 * time.Second,
+	}
+}
+
+// GetJSON performs a GET request and unmarshals the JSON response into target.
+func (c *Client) GetJSON(endpoint string, target interface{}) error {
+	url := BuildApiUrl(endpoint)
+
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return fmt.Errorf("failed to create request: %w", err)
+	}
+
+	return c.doWithRetry(req, target)
+}
+
+// PostJSON performs a POST request with optional JSON body and unmarshals the response.
+// If body is nil, sends an empty POST request.
+// If target is nil, response body is not unmarshaled.
+func (c *Client) PostJSON(endpoint string, body interface{}, target interface{}) error {
+	url := BuildApiUrl(endpoint)
+
+	var bodyReader io.Reader
+	var jsonData []byte
+	if body != nil {
+		var err error
+		jsonData, err = json.Marshal(body)
+		if err != nil {
+			return fmt.Errorf("failed to marshal request body: %w", err)
+		}
+		slog.Debug("JSON payload created", "payload", string(jsonData))
+		bodyReader = bytes.NewReader(jsonData)
+	}
+
+	req, err := http.NewRequest("POST", url, bodyReader)
+	if err != nil {
+		return fmt.Errorf("failed to create request: %w", err)
+	}
+
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+		// Set GetBody to allow body recreation for retries
+		req.GetBody = func() (io.ReadCloser, error) {
+			return io.NopCloser(bytes.NewReader(jsonData)), nil
+		}
+	}
+
+	return c.doWithRetry(req, target)
+}
+
+// doWithRetry executes the request with exponential backoff retry logic.
+func (c *Client) doWithRetry(req *http.Request, target interface{}) error {
+	var lastErr error
+
+	for attempt := 1; attempt <= c.maxRetries; attempt++ {
+		if attempt > 1 {
+			backoff := c.calculateBackoff(attempt - 1)
+			slog.Debug("Retrying request", "attempt", attempt, "backoff", backoff, "url", req.URL.String())
+			time.Sleep(backoff)
+
+			// Recreate body reader for retry if needed
+			if req.GetBody != nil {
+				body, err := req.GetBody()
+				if err != nil {
+					return fmt.Errorf("failed to recreate request body for retry: %w", err)
+				}
+				req.Body = body
+			}
+		}
+
+		slog.Debug("Sending request",
+			"url", req.URL.String(),
+			"method", req.Method,
+			"attempt", attempt,
+			"maxAttempts", c.maxRetries)
+
+		resp, err := c.httpClient.Do(req)
+		if err != nil {
+			lastErr = fmt.Errorf("request failed (attempt %d/%d): %w", attempt, c.maxRetries, err)
+			slog.Debug("Request attempt failed", "error", err, "attempt", attempt)
+			continue
+		}
+
+		// Handle response
+		result, err := c.handleResponse(resp, target)
+		if err != nil {
+			lastErr = err
+			// Retry on server errors (5xx)
+			if httpErr, ok := err.(*HTTPError); ok && httpErr.StatusCode >= 500 {
+				slog.Debug("Server error, will retry", "status", httpErr.StatusCode, "attempt", attempt)
+				continue
+			}
+			// Don't retry client errors (4xx) or other errors
+			return err
+		}
+
+		if result {
+			return nil
+		}
+	}
+
+	return fmt.Errorf("request failed after %d attempts: %w", c.maxRetries, lastErr)
+}
+
+// handleResponse processes the HTTP response, returning true on success.
+func (c *Client) handleResponse(resp *http.Response, target interface{}) (bool, error) {
+	defer func() {
+		if cerr := resp.Body.Close(); cerr != nil {
+			slog.Warn("Error closing response body", "error", cerr)
+		}
+	}()
+
+	// Read body
+	bodyBytes, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return false, fmt.Errorf("failed to read response body: %w", err)
+	}
+
+	// Check for success status (2xx)
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return false, &HTTPError{
+			StatusCode: resp.StatusCode,
+			Status:     resp.Status,
+			Body:       string(bodyBytes),
+			URL:        resp.Request.URL.String(),
+		}
+	}
+
+	// Unmarshal if target provided
+	if target != nil && len(bodyBytes) > 0 {
+		if err := json.Unmarshal(bodyBytes, target); err != nil {
+			return false, fmt.Errorf("failed to unmarshal response: %w", err)
+		}
+	}
+
+	slog.Debug("Request completed successfully", "status", resp.Status)
+	return true, nil
+}
+
+// calculateBackoff returns exponential backoff delay: 1s, 2s, 4s
+func (c *Client) calculateBackoff(attempt int) time.Duration {
+	multiplier := math.Pow(2, float64(attempt-1))
+	return time.Duration(multiplier) * c.baseBackoff
+}
+
+// HTTPError represents an HTTP error response.
+type HTTPError struct {
+	StatusCode int
+	Status     string
+	Body       string
+	URL        string
+}
+
+func (e *HTTPError) Error() string {
+	return fmt.Sprintf("HTTP %d: %s (URL: %s)", e.StatusCode, e.Status, e.URL)
+}
+
+// IsHTTPError checks if error is an HTTPError and returns it.
+func IsHTTPError(err error) (*HTTPError, bool) {
+	httpErr, ok := err.(*HTTPError)
+	return httpErr, ok
+}

--- a/cmd/utils/httpclient_test.go
+++ b/cmd/utils/httpclient_test.go
@@ -1,0 +1,381 @@
+package utils
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/spf13/viper"
+)
+
+func init() {
+	// Set up a default base URL for tests
+	viper.Set("api.base_url", "http://localhost:8080")
+}
+
+// MockHTTPClient is a mock implementation of HTTPClient for testing.
+type MockHTTPClient struct {
+	DoFunc func(req *http.Request) (*http.Response, error)
+}
+
+func (m *MockHTTPClient) Do(req *http.Request) (*http.Response, error) {
+	return m.DoFunc(req)
+}
+
+// newMockResponse creates a mock HTTP response.
+func newMockResponse(statusCode int, body string) *http.Response {
+	// Create a minimal request to avoid nil pointer issues
+	req, _ := http.NewRequest("GET", "http://localhost:8080/test", nil)
+	return &http.Response{
+		StatusCode: statusCode,
+		Status:     http.StatusText(statusCode),
+		Body:       io.NopCloser(bytes.NewBufferString(body)),
+		Header:     make(http.Header),
+		Request:    req,
+	}
+}
+
+func TestClient_GetJSON_Success(t *testing.T) {
+	mockClient := &MockHTTPClient{
+		DoFunc: func(req *http.Request) (*http.Response, error) {
+			if req.Method != "GET" {
+				t.Errorf("Expected GET method, got: %s", req.Method)
+			}
+			return newMockResponse(200, `["Project1", "Project2"]`), nil
+		},
+	}
+
+	client := NewClientWithHTTPClient(mockClient)
+	var projects []string
+
+	err := client.GetJSON("/api/v2/projects", &projects)
+	if err != nil {
+		t.Fatalf("Expected no error, got: %v", err)
+	}
+
+	if len(projects) != 2 {
+		t.Errorf("Expected 2 projects, got: %d", len(projects))
+	}
+
+	if projects[0] != "Project1" {
+		t.Errorf("Expected first project 'Project1', got: %s", projects[0])
+	}
+}
+
+func TestClient_GetJSON_EmptyResponse(t *testing.T) {
+	mockClient := &MockHTTPClient{
+		DoFunc: func(req *http.Request) (*http.Response, error) {
+			return newMockResponse(200, ""), nil
+		},
+	}
+
+	client := NewClientWithHTTPClient(mockClient)
+	var result interface{}
+
+	err := client.GetJSON("/api/v2/test", &result)
+	if err != nil {
+		t.Fatalf("Expected no error for empty response, got: %v", err)
+	}
+}
+
+func TestClient_GetJSON_HTTPError(t *testing.T) {
+	mockClient := &MockHTTPClient{
+		DoFunc: func(req *http.Request) (*http.Response, error) {
+			return newMockResponse(404, `{"error": "not found"}`), nil
+		},
+	}
+
+	client := NewClientWithHTTPClient(mockClient)
+	var result interface{}
+
+	err := client.GetJSON("/api/v2/test", &result)
+	if err == nil {
+		t.Fatal("Expected error for 404 response")
+	}
+
+	httpErr, ok := IsHTTPError(err)
+	if !ok {
+		t.Fatalf("Expected HTTPError, got: %T", err)
+	}
+
+	if httpErr.StatusCode != 404 {
+		t.Errorf("Expected status code 404, got: %d", httpErr.StatusCode)
+	}
+
+	if httpErr.Body != `{"error": "not found"}` {
+		t.Errorf("Expected body to be preserved, got: %s", httpErr.Body)
+	}
+}
+
+func TestClient_PostJSON_Success(t *testing.T) {
+	mockClient := &MockHTTPClient{
+		DoFunc: func(req *http.Request) (*http.Response, error) {
+			if req.Method != "POST" {
+				t.Errorf("Expected POST method, got: %s", req.Method)
+			}
+			if req.Header.Get("Content-Type") != "application/json" {
+				t.Errorf("Expected Content-Type application/json, got: %s", req.Header.Get("Content-Type"))
+			}
+			return newMockResponse(200, `{"success": true}`), nil
+		},
+	}
+
+	client := NewClientWithHTTPClient(mockClient)
+	payload := map[string]string{"key": "value"}
+	var result map[string]bool
+
+	err := client.PostJSON("/api/v2/test", payload, &result)
+	if err != nil {
+		t.Fatalf("Expected no error, got: %v", err)
+	}
+
+	if !result["success"] {
+		t.Error("Expected success to be true")
+	}
+}
+
+func TestClient_PostJSON_NilBody(t *testing.T) {
+	mockClient := &MockHTTPClient{
+		DoFunc: func(req *http.Request) (*http.Response, error) {
+			if req.Method != "POST" {
+				t.Errorf("Expected POST method, got: %s", req.Method)
+			}
+			// Content-Type should not be set for nil body
+			if req.Header.Get("Content-Type") != "" {
+				t.Errorf("Expected no Content-Type for nil body, got: %s", req.Header.Get("Content-Type"))
+			}
+			return newMockResponse(202, ""), nil
+		},
+	}
+
+	client := NewClientWithHTTPClient(mockClient)
+
+	err := client.PostJSON("/api/v2/test", nil, nil)
+	if err != nil {
+		t.Fatalf("Expected no error, got: %v", err)
+	}
+}
+
+func TestClient_PostJSON_AcceptedStatus(t *testing.T) {
+	mockClient := &MockHTTPClient{
+		DoFunc: func(req *http.Request) (*http.Response, error) {
+			return newMockResponse(202, ""), nil
+		},
+	}
+
+	client := NewClientWithHTTPClient(mockClient)
+
+	err := client.PostJSON("/api/v2/test", nil, nil)
+	if err != nil {
+		t.Fatalf("Expected no error for 202 Accepted, got: %v", err)
+	}
+}
+
+func TestClient_Retry_OnNetworkError(t *testing.T) {
+	var attempts int32
+
+	mockClient := &MockHTTPClient{
+		DoFunc: func(req *http.Request) (*http.Response, error) {
+			atomic.AddInt32(&attempts, 1)
+			current := atomic.LoadInt32(&attempts)
+			if current < 3 {
+				return nil, errors.New("network error")
+			}
+			return newMockResponse(200, `{"success": true}`), nil
+		},
+	}
+
+	client := NewClientWithHTTPClient(mockClient)
+	client.baseBackoff = 10 * time.Millisecond // Speed up test
+	var result map[string]bool
+
+	err := client.GetJSON("/api/v2/test", &result)
+	if err != nil {
+		t.Fatalf("Expected success after retries, got: %v", err)
+	}
+
+	if atomic.LoadInt32(&attempts) != 3 {
+		t.Errorf("Expected 3 attempts, got: %d", attempts)
+	}
+}
+
+func TestClient_Retry_OnServerError(t *testing.T) {
+	var attempts int32
+
+	mockClient := &MockHTTPClient{
+		DoFunc: func(req *http.Request) (*http.Response, error) {
+			atomic.AddInt32(&attempts, 1)
+			current := atomic.LoadInt32(&attempts)
+			if current < 3 {
+				return newMockResponse(500, "Server Error"), nil
+			}
+			return newMockResponse(200, `{"success": true}`), nil
+		},
+	}
+
+	client := NewClientWithHTTPClient(mockClient)
+	client.baseBackoff = 10 * time.Millisecond // Speed up test
+	var result map[string]bool
+
+	err := client.GetJSON("/api/v2/test", &result)
+	if err != nil {
+		t.Fatalf("Expected success after retries, got: %v", err)
+	}
+
+	if atomic.LoadInt32(&attempts) != 3 {
+		t.Errorf("Expected 3 attempts, got: %d", attempts)
+	}
+}
+
+func TestClient_NoRetry_OnClientError(t *testing.T) {
+	var attempts int32
+
+	mockClient := &MockHTTPClient{
+		DoFunc: func(req *http.Request) (*http.Response, error) {
+			atomic.AddInt32(&attempts, 1)
+			return newMockResponse(400, "Bad Request"), nil
+		},
+	}
+
+	client := NewClientWithHTTPClient(mockClient)
+	client.baseBackoff = 10 * time.Millisecond
+	var result interface{}
+
+	err := client.GetJSON("/api/v2/test", &result)
+	if err == nil {
+		t.Fatal("Expected error for 400 response")
+	}
+
+	// Should not retry on 4xx errors
+	if atomic.LoadInt32(&attempts) != 1 {
+		t.Errorf("Expected 1 attempt (no retry for 4xx), got: %d", attempts)
+	}
+}
+
+func TestClient_MaxRetries_Exceeded(t *testing.T) {
+	var attempts int32
+
+	mockClient := &MockHTTPClient{
+		DoFunc: func(req *http.Request) (*http.Response, error) {
+			atomic.AddInt32(&attempts, 1)
+			return nil, errors.New("network error")
+		},
+	}
+
+	client := NewClientWithHTTPClient(mockClient)
+	client.baseBackoff = 10 * time.Millisecond
+	var result interface{}
+
+	err := client.GetJSON("/api/v2/test", &result)
+	if err == nil {
+		t.Fatal("Expected error after max retries")
+	}
+
+	if atomic.LoadInt32(&attempts) != 3 {
+		t.Errorf("Expected 3 attempts, got: %d", attempts)
+	}
+}
+
+func TestClient_CalculateBackoff(t *testing.T) {
+	client := NewClient()
+
+	tests := []struct {
+		attempt  int
+		expected time.Duration
+	}{
+		{1, 1 * time.Second},  // 2^0 = 1
+		{2, 2 * time.Second},  // 2^1 = 2
+		{3, 4 * time.Second},  // 2^2 = 4
+		{4, 8 * time.Second},  // 2^3 = 8
+	}
+
+	for _, tt := range tests {
+		got := client.calculateBackoff(tt.attempt)
+		if got != tt.expected {
+			t.Errorf("calculateBackoff(%d) = %v, expected %v", tt.attempt, got, tt.expected)
+		}
+	}
+}
+
+func TestHTTPError_Formatting(t *testing.T) {
+	err := &HTTPError{
+		StatusCode: 404,
+		Status:     "404 Not Found",
+		URL:        "http://localhost/api/test",
+		Body:       "Resource not found",
+	}
+
+	expected := "HTTP 404: 404 Not Found (URL: http://localhost/api/test)"
+	if err.Error() != expected {
+		t.Errorf("Expected error message: %s, got: %s", expected, err.Error())
+	}
+}
+
+func TestIsHTTPError(t *testing.T) {
+	httpErr := &HTTPError{StatusCode: 500}
+	otherErr := errors.New("other error")
+
+	if got, ok := IsHTTPError(httpErr); !ok || got.StatusCode != 500 {
+		t.Error("IsHTTPError should return true for HTTPError")
+	}
+
+	if _, ok := IsHTTPError(otherErr); ok {
+		t.Error("IsHTTPError should return false for non-HTTPError")
+	}
+}
+
+// Integration test using httptest server
+func TestClient_Integration_WithHTTPTestServer(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v2/projects":
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`["Project1", "Project2", "Project3"]`))
+		case "/api/v2/process/start":
+			if r.Method != "POST" {
+				w.WriteHeader(http.StatusMethodNotAllowed)
+				return
+			}
+			w.WriteHeader(http.StatusAccepted)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	// Create client that points to test server
+	client := &Client{
+		httpClient: &http.Client{
+			Timeout: 5 * time.Second,
+		},
+		maxRetries:  3,
+		baseBackoff: 10 * time.Millisecond,
+	}
+
+	t.Run("GET projects", func(t *testing.T) {
+		var projects []string
+		// Note: We need to build URL manually for test server
+		req, _ := http.NewRequest("GET", server.URL+"/api/v2/projects", nil)
+		err := client.doWithRetry(req, &projects)
+		if err != nil {
+			t.Fatalf("Expected no error, got: %v", err)
+		}
+		if len(projects) != 3 {
+			t.Errorf("Expected 3 projects, got: %d", len(projects))
+		}
+	})
+
+	t.Run("POST start process", func(t *testing.T) {
+		req, _ := http.NewRequest("POST", server.URL+"/api/v2/process/start", nil)
+		err := client.doWithRetry(req, nil)
+		if err != nil {
+			t.Fatalf("Expected no error for 202 response, got: %v", err)
+		}
+	})
+}


### PR DESCRIPTION
## Summary

- Create reusable HTTP client abstraction in `cmd/utils/httpclient.go` with `GetJSON()` and `PostJSON()` methods
- Add 30-second timeout and retry logic with exponential backoff (1s, 2s, 4s)
- Refactor all 5 command files to use the new client, reducing code by ~220 lines
- Add DRY helper functions for process formatting and error handling
- Replace `os.Exit(1)` calls with `return` for better testability

Resolves #2

## Test plan

- [x] All existing tests pass (`go test -v ./...`)
- [x] New HTTP client tests added with mock client and httptest server
- [x] Build succeeds (`go build -o ftsctl`)
- [x] Manual testing with live API