### PR TITLE
refactor: standardize error handling across commands

### DIFF
--- a/cmd/config/config.go
+++ b/cmd/config/config.go
@@ -11,15 +11,12 @@ var Cmd = &cobra.Command{
 	Short: "Manage CLI configuration",
 	Long: `Provides commands to manage ftsctl configuration,
 including viewing current settings and updating the base API URL.`,
-	SilenceErrors: true,
-	SilenceUsage:  true,
-	Run: func(cmd *cobra.Command, args []string) {
+	SilenceUsage: true,
+	RunE: func(cmd *cobra.Command, args []string) error {
 		if len(args) == 0 {
-			fmt.Println("Please specify a subcommand. Use 'ftsctl config --help' to see available options.")
-			return
+			return fmt.Errorf("please specify a subcommand (use '%s --help' to see available options)", cmd.CommandPath())
 		}
-		fmt.Printf("Error: unknown subcommand '%s'\n", args[0])
-		fmt.Println("Use 'ftsctl config --help' to see available subcommands.")
+		return fmt.Errorf("unknown subcommand '%s' (use '%s --help' to see available subcommands)", args[0], cmd.CommandPath())
 	},
 }
 

--- a/cmd/config/setBaseUrl.go
+++ b/cmd/config/setBaseUrl.go
@@ -3,7 +3,6 @@ package config
 import (
 	"fmt"
 	"log/slog"
-	"os"
 
 	"ftsctl/cmd/utils"
 
@@ -18,23 +17,20 @@ var SetBaseUrlCmd = &cobra.Command{
 Example:
   ftsctl config set-base-url http://localhost:8080
   ftsctl config set-base-url https://api.example.com`,
-	Args: cobra.ExactArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
+	Args:         cobra.ExactArgs(1),
+	SilenceUsage: true,
+	RunE: func(cmd *cobra.Command, args []string) error {
 		urlArg := args[0]
 
 		validatedUrl, err := utils.ValidateURL(urlArg)
 		if err != nil {
-			slog.Error("URL validation failed", "url", urlArg, "error", err)
-			fmt.Printf("Error: %v\n", err)
-			os.Exit(1)
+			return fmt.Errorf("URL validation failed: %w", err)
 		}
 
 		slog.Debug("Validated URL", "url", validatedUrl)
 
 		if err := utils.WriteConfig(validatedUrl); err != nil {
-			slog.Error("Failed to write config", "error", err)
-			fmt.Printf("Error: %v\n", err)
-			os.Exit(1)
+			return fmt.Errorf("failed to write configuration: %w", err)
 		}
 
 		configPath, err := utils.GetConfigPath()
@@ -49,6 +45,7 @@ Example:
 		fmt.Printf("Base URL: %s\n", validatedUrl)
 		fmt.Printf("Config file: %s\n", configPath)
 		utils.DivdlnS()
+		return nil
 	},
 }
 

--- a/cmd/config/show.go
+++ b/cmd/config/show.go
@@ -3,7 +3,6 @@ package config
 import (
 	"fmt"
 	"log/slog"
-	"os"
 
 	"ftsctl/cmd/utils"
 
@@ -12,15 +11,14 @@ import (
 )
 
 var ShowCmd = &cobra.Command{
-	Use:   "show",
-	Short: "Display current configuration",
-	Long:  `Display the current configuration settings.`,
-	Run: func(cmd *cobra.Command, args []string) {
+	Use:          "show",
+	Short:        "Display current configuration",
+	Long:         `Display the current configuration settings.`,
+	SilenceUsage: true,
+	RunE: func(cmd *cobra.Command, args []string) error {
 		configPath, err := utils.GetConfigPath()
 		if err != nil {
-			slog.Error("Failed to get config path", "error", err)
-			fmt.Printf("Error: %v\n", err)
-			os.Exit(1)
+			return fmt.Errorf("failed to get config path: %w", err)
 		}
 
 		if !utils.ConfigExists() {
@@ -29,7 +27,7 @@ var ShowCmd = &cobra.Command{
 			fmt.Printf("Expected location: %s\n", configPath)
 			fmt.Println("\nRun 'ftsctl config set-base-url <url>' to create one.")
 			utils.DivdlnL()
-			return
+			return nil
 		}
 
 		baseUrl := viper.GetString("api.base_url")
@@ -42,6 +40,7 @@ var ShowCmd = &cobra.Command{
 		utils.DivdlnS()
 
 		slog.Debug("Displayed config", "base_url", baseUrl, "path", configPath)
+		return nil
 	},
 }
 

--- a/cmd/process/listProcesses.go
+++ b/cmd/process/listProcesses.go
@@ -8,15 +8,16 @@ import (
 )
 
 var listProcessesCmd = &cobra.Command{
-	Use:   "list",
-	Short: "List all transfer process statuses",
-	Long:  `Lists all available transfer process statuses.`,
-	Run: func(cmdCobra *cobra.Command, args []string) {
+	Use:          "list",
+	Short:        "List all transfer process statuses",
+	Long:         `Lists all available transfer process statuses.`,
+	SilenceUsage: true,
+	RunE: func(cmd *cobra.Command, args []string) error {
 		client := utils.NewClient()
 		var processes []utils.Process
 
-		if err := client.GetJSON("/api/v2/process/statuses", &processes); utils.LogHTTPError(err, "fetch process statuses") {
-			return
+		if err := client.GetJSON("/api/v2/process/statuses", &processes); err != nil {
+			return fmt.Errorf("failed to fetch process statuses: %w", err)
 		}
 
 		utils.DivdlnL()
@@ -27,6 +28,7 @@ var listProcessesCmd = &cobra.Command{
 			utils.PrintProcessStatus(p)
 			utils.DivdlnS()
 		}
+		return nil
 	},
 }
 

--- a/cmd/process/process.go
+++ b/cmd/process/process.go
@@ -12,19 +12,15 @@ import (
 var Cmd = &cobra.Command{
 	Use:   "process",
 	Short: "Inspect and monitor transfer processes",
-	Long: `Provides commands to inspect and monitor transfer processes, 
-including listing all available processes and showing the status 
+	Long: `Provides commands to inspect and monitor transfer processes,
+including listing all available processes and showing the status
 of a specific process.`,
-	SilenceErrors: true,
-	SilenceUsage:  true,
-	Run: func(cmd *cobra.Command, args []string) {
+	SilenceUsage: true,
+	RunE: func(cmd *cobra.Command, args []string) error {
 		if len(args) == 0 {
-			fmt.Println("Please specify a subcommand. Use 'ftsctl process --help' to see available options.")
-			return
+			return fmt.Errorf("please specify a subcommand (use '%s --help' to see available options)", cmd.CommandPath())
 		}
-		// unknown subcommand
-		fmt.Printf("Error: unknown subcommand '%s'\n", args[0])
-		fmt.Println("Use 'ftsctl process --help' to see available subcommands.")
+		return fmt.Errorf("unknown subcommand '%s' (use '%s --help' to see available subcommands)", args[0], cmd.CommandPath())
 	},
 }
 

--- a/cmd/process/processStatus.go
+++ b/cmd/process/processStatus.go
@@ -10,22 +10,16 @@ import (
 var processId string
 
 var StatusCmd = &cobra.Command{
-	Use:   "status",
-	Short: "Show process status",
-	Long:  `Shows the process status of the selected process ID`,
-	Run: func(cmd *cobra.Command, args []string) {
-		if !cmd.Flags().Changed("processId") {
-			utils.DivdlnL()
-			fmt.Printf("Warning: No --processId (-i) specified.\n\nPlease set the flag to retrieve the status of a process.\n")
-			utils.DivdlnL()
-			return
-		}
-
+	Use:          "status",
+	Short:        "Show process status",
+	Long:         `Shows the process status of the selected process ID`,
+	SilenceUsage: true,
+	RunE: func(cmd *cobra.Command, args []string) error {
 		client := utils.NewClient()
 		var prcss utils.Process
 
-		if err := client.GetJSON("/api/v2/process/status/"+processId, &prcss); utils.LogHTTPError(err, "fetch process status") {
-			return
+		if err := client.GetJSON("/api/v2/process/status/"+processId, &prcss); err != nil {
+			return fmt.Errorf("failed to fetch status for process %q: %w", processId, err)
 		}
 
 		utils.DivdlnL()
@@ -33,10 +27,12 @@ var StatusCmd = &cobra.Command{
 		utils.DivdlnL()
 		utils.PrintProcessStatus(prcss)
 		utils.DivdlnS()
+		return nil
 	},
 }
 
 func init() {
-	StatusCmd.Flags().StringVarP(&processId, "processId", "i", "", "Please Enter the processId")
+	StatusCmd.Flags().StringVarP(&processId, "processId", "i", "", "Process ID to query")
+	_ = StatusCmd.MarkFlagRequired("processId")
 	Cmd.AddCommand(StatusCmd)
 }

--- a/cmd/project/listProjects.go
+++ b/cmd/project/listProjects.go
@@ -8,16 +8,16 @@ import (
 )
 
 var ListProjectsCmd = &cobra.Command{
-	Use:   "list", // /api/v2/projects
-	Short: "List of all available projects",
-	Long:  `List of all available projects from the API.`,
-
-	Run: func(cmd *cobra.Command, args []string) {
+	Use:          "list",
+	Short:        "List of all available projects",
+	Long:         `List of all available projects from the API.`,
+	SilenceUsage: true,
+	RunE: func(cmd *cobra.Command, args []string) error {
 		client := utils.NewClient()
 		var projects []string
 
-		if err := client.GetJSON("/api/v2/projects", &projects); utils.LogHTTPError(err, "fetch projects") {
-			return
+		if err := client.GetJSON("/api/v2/projects", &projects); err != nil {
+			return fmt.Errorf("failed to fetch projects: %w", err)
 		}
 
 		utils.DivdlnL()
@@ -27,6 +27,7 @@ var ListProjectsCmd = &cobra.Command{
 			fmt.Printf("%d. %s\n", i+1, project)
 		}
 		utils.DivdlnS()
+		return nil
 	},
 }
 

--- a/cmd/project/project.go
+++ b/cmd/project/project.go
@@ -12,19 +12,15 @@ import (
 var Cmd = &cobra.Command{
 	Use:   "project",
 	Short: "Inspect and monitor projects",
-	Long: `Provides commands to	inspect projects, 
-including listing all available projects and showing the 
+	Long: `Provides commands to	inspect projects,
+including listing all available projects and showing the
 configuration of a selected project.`,
-	SilenceErrors: true,
-	SilenceUsage:  true,
-	Run: func(cmd *cobra.Command, args []string) {
+	SilenceUsage: true,
+	RunE: func(cmd *cobra.Command, args []string) error {
 		if len(args) == 0 {
-			fmt.Println("Please specify a subcommand. Use 'ftsctl project --help' to see available options.")
-			return
+			return fmt.Errorf("please specify a subcommand (use '%s --help' to see available options)", cmd.CommandPath())
 		}
-		// unknown subcommand
-		fmt.Printf("Error: unknown subcommand '%s'\n", args[0])
-		fmt.Println("Use 'ftsctl project --help' to see available subcommands.")
+		return fmt.Errorf("unknown subcommand '%s' (use '%s --help' to see available subcommands)", args[0], cmd.CommandPath())
 	},
 }
 

--- a/cmd/project/projectConfig.go
+++ b/cmd/project/projectConfig.go
@@ -78,22 +78,16 @@ type ResearchDomainAgent struct {
 var PrjName string
 
 var ConfigCmd = &cobra.Command{
-	Use:   "config",
-	Short: "Project configuration",
-	Long:  `Shows the project configuration of the selected project.`,
-	Run: func(cmd *cobra.Command, args []string) {
-		if !cmd.Flags().Changed("projectName") {
-			utils.DivdlnL()
-			fmt.Printf("Warning: No --projectName (-n) specified.\n\nPlease set the Flag to retrieve the Project Configuration of a Project.\n")
-			utils.DivdlnL()
-			return
-		}
-
+	Use:          "config",
+	Short:        "Project configuration",
+	Long:         `Shows the project configuration of the selected project.`,
+	SilenceUsage: true,
+	RunE: func(cmd *cobra.Command, args []string) error {
 		client := utils.NewClient()
 		var pConfig Config
 
-		if err := client.GetJSON("/api/v2/projects/"+PrjName, &pConfig); utils.LogHTTPError(err, "fetch project config") {
-			return
+		if err := client.GetJSON("/api/v2/projects/"+PrjName, &pConfig); err != nil {
+			return fmt.Errorf("failed to fetch configuration for project %q: %w", PrjName, err)
 		}
 
 		// Formatted Output
@@ -132,10 +126,12 @@ var ConfigCmd = &cobra.Command{
 		fmt.Printf("  Server BaseURL: %s\n", pConfig.BundleSender.ResearchDomainAgent.Server.BaseUrl)
 		fmt.Printf("  Project: %s\n", pConfig.BundleSender.ResearchDomainAgent.Project)
 		utils.DivdlnS()
+		return nil
 	},
 }
 
 func init() {
-	ConfigCmd.Flags().StringVarP(&PrjName, "projectName", "n", "", "Please Enter the Name of the Project")
+	ConfigCmd.Flags().StringVarP(&PrjName, "projectName", "n", "", "Name of the project")
+	_ = ConfigCmd.MarkFlagRequired("projectName")
 	Cmd.AddCommand(ConfigCmd)
 }

--- a/cmd/transfer/startTransfer.go
+++ b/cmd/transfer/startTransfer.go
@@ -15,15 +15,11 @@ var startTransferCmd = &cobra.Command{
 	Long: `Start a transfer of patients with IDs provided in the request
 body, or if none are provided, start a transfer of all consented
 patients for the specified project.`,
-	Run: func(cmd *cobra.Command, args []string) {
+	SilenceUsage: true,
+	RunE: func(cmd *cobra.Command, args []string) error {
 		projectName, _ := cmd.Flags().GetString("projectName")
-		if projectName == "" {
-			fmt.Println("ERROR: The --projectName (-n) flag is required!")
-			fmt.Println("Usage: ftsctl startTransfer --projectName exampleProject [--ids id1,id2,id3]")
-			return
-		}
-
 		idsStr, _ := cmd.Flags().GetString("ids")
+
 		var ids []string
 		if idsStr != "" {
 			ids = strings.Split(idsStr, ",")
@@ -37,8 +33,8 @@ patients for the specified project.`,
 			body = ids
 		}
 
-		if err := client.PostJSON(endpoint, body, nil); utils.PrintHTTPError(err) {
-			return
+		if err := client.PostJSON(endpoint, body, nil); err != nil {
+			return fmt.Errorf("failed to start transfer for project %q: %w", projectName, err)
 		}
 
 		utils.DivdlnL()
@@ -52,12 +48,13 @@ patients for the specified project.`,
 		}
 		slog.Debug("Transfer request completed", "project", projectName)
 		utils.DivdlnS()
+		return nil
 	},
 }
 
 func init() {
 	startTransferCmd.Flags().StringP("projectName", "n", "", "Project name (required)")
 	startTransferCmd.Flags().StringP("ids", "i", "", "Comma-separated list of patient IDs (optional)")
-
+	_ = startTransferCmd.MarkFlagRequired("projectName")
 	Cmd.AddCommand(startTransferCmd)
 }

--- a/cmd/transfer/transfer.go
+++ b/cmd/transfer/transfer.go
@@ -13,18 +13,14 @@ import (
 var Cmd = &cobra.Command{
 	Use:   "transfer",
 	Short: "Start transfer processes",
-	Long: `Provides commands to start transfer processes, 
+	Long: `Provides commands to start transfer processes,
 such as initiating a transfer of consented patients in a project.`,
-	SilenceErrors: true,
-	SilenceUsage:  true,
-	Run: func(cmd *cobra.Command, args []string) {
+	SilenceUsage: true,
+	RunE: func(cmd *cobra.Command, args []string) error {
 		if len(args) == 0 {
-			fmt.Println("Please specify a subcommand. Use 'ftsctl transfer --help' to see available options.")
-			return
+			return fmt.Errorf("please specify a subcommand (use '%s --help' to see available options)", cmd.CommandPath())
 		}
-		// unknown subcommand
-		fmt.Printf("Error: unknown subcommand '%s'\n", args[0])
-		fmt.Println("Use 'ftsctl transfer --help' to see available subcommands.")
+		return fmt.Errorf("unknown subcommand '%s' (use '%s --help' to see available subcommands)", args[0], cmd.CommandPath())
 	},
 }
 

--- a/cmd/utils/apiUrl.go
+++ b/cmd/utils/apiUrl.go
@@ -1,29 +1,32 @@
 package utils
 
 import (
-	"github.com/spf13/viper"
-	"log"
+	"fmt"
 	"net/url"
+
+	"github.com/spf13/viper"
 )
 
-// GetBaseURL Import baseUrl from config.yaml
-func GetBaseURL() *url.URL {
+// GetBaseURL returns the base URL from config.yaml or an error if not configured.
+func GetBaseURL() (*url.URL, error) {
 	baseUrlString := viper.GetString("api.base_url")
 	if baseUrlString == "" {
-		log.Fatal("Base API URL is not set in the configuration file")
+		return nil, fmt.Errorf("base API URL is not set (use 'ftsctl config set-base-url' to configure)")
 	}
 
-	// Parse baseUrl into url.URL
 	baseUrl, err := url.Parse(baseUrlString)
 	if err != nil {
-		log.Fatalf("Invalid URL format: %v", err)
+		return nil, fmt.Errorf("invalid URL format: %w", err)
 	}
 
-	return baseUrl
+	return baseUrl, nil
 }
 
-// BuildApiUrl combines the base URL with a specific API endpoint
-
-func BuildApiUrl(endpoint string) string {
-	return GetBaseURL().ResolveReference(&url.URL{Path: endpoint}).String()
+// BuildApiUrl combines the base URL with a specific API endpoint.
+func BuildApiUrl(endpoint string) (string, error) {
+	baseUrl, err := GetBaseURL()
+	if err != nil {
+		return "", err
+	}
+	return baseUrl.ResolveReference(&url.URL{Path: endpoint}).String(), nil
 }

--- a/cmd/utils/format.go
+++ b/cmd/utils/format.go
@@ -2,7 +2,6 @@ package utils
 
 import (
 	"fmt"
-	"log/slog"
 	"time"
 )
 
@@ -68,38 +67,4 @@ func PrintProcessStatus(p Process) {
 	fmt.Printf("DeidentifiedBundles: %d\n", p.DeidentifiedBundles)
 	fmt.Printf("SentBundles: %d\n", p.SentBundles)
 	fmt.Printf("SkippedBundles: %d\n", p.SkippedBundles)
-}
-
-// LogHTTPError logs an HTTP error appropriately and returns true if an error was handled.
-func LogHTTPError(err error, context string) bool {
-	if err == nil {
-		return false
-	}
-
-	if httpErr, ok := IsHTTPError(err); ok {
-		slog.Error("API request failed", "context", context, "status", httpErr.Status, "details", httpErr.Body)
-	} else {
-		slog.Error("Request failed", "context", context, "error", err)
-	}
-	return true
-}
-
-// PrintHTTPError prints an HTTP error in a user-friendly format and returns true if an error was handled.
-// Use this when you want to display error details to the user (not just log them).
-func PrintHTTPError(err error) bool {
-	if err == nil {
-		return false
-	}
-
-	DivdlnL()
-	if httpErr, ok := IsHTTPError(err); ok {
-		fmt.Printf("Request failed! Response Status: %s\n", httpErr.Status)
-		if httpErr.Body != "" {
-			fmt.Printf("Server response body:\n%s\n", httpErr.Body)
-		}
-	} else {
-		slog.Error("Request failed", "error", err)
-	}
-	DivdlnL()
-	return true
 }

--- a/cmd/utils/httpclient.go
+++ b/cmd/utils/httpclient.go
@@ -49,7 +49,10 @@ func NewClientWithHTTPClient(httpClient HTTPClient) *Client {
 
 // GetJSON performs a GET request and unmarshals the JSON response into target.
 func (c *Client) GetJSON(endpoint string, target interface{}) error {
-	url := BuildApiUrl(endpoint)
+	url, err := BuildApiUrl(endpoint)
+	if err != nil {
+		return fmt.Errorf("failed to build API URL: %w", err)
+	}
 
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
@@ -63,7 +66,10 @@ func (c *Client) GetJSON(endpoint string, target interface{}) error {
 // If body is nil, sends an empty POST request.
 // If target is nil, response body is not unmarshaled.
 func (c *Client) PostJSON(endpoint string, body interface{}, target interface{}) error {
-	url := BuildApiUrl(endpoint)
+	url, err := BuildApiUrl(endpoint)
+	if err != nil {
+		return fmt.Errorf("failed to build API URL: %w", err)
+	}
 
 	var bodyReader io.Reader
 	var jsonData []byte


### PR DESCRIPTION
## Summary
- Convert all Cobra commands from `Run` to `RunE` pattern with proper error propagation
- Replace `log.Fatal()` in apiUrl.go with error returns
- Remove `LogHTTPError`/`PrintHTTPError` helpers from format.go
- Update httpclient.go to handle `BuildApiUrl` errors
- Use `MarkFlagRequired` for projectName and processId flags
- Add `SilenceUsage` to all commands to prevent verbose output on errors
- Remove `SilenceErrors` from parent commands to show error messages

## Test plan
- [ ] Run `go test -v ./...` - all tests pass
- [ ] Verify `ftsctl project list` works with valid config
- [ ] Verify `ftsctl project config` without `-n` flag shows proper error and exit code 1
- [ ] Verify `ftsctl project config -n nonexistent` shows HTTP error with exit code 1
- [ ] Verify `ftsctl project` (no subcommand) shows proper error message

Closes #3