### PR TITLE
Rename BuildApiUrl to BuildAPIURL per Go conventions

### DIFF
--- a/cmd/utils/apiUrl.go
+++ b/cmd/utils/apiUrl.go
@@ -22,8 +22,8 @@ func GetBaseURL() (*url.URL, error) {
 	return baseUrl, nil
 }
 
-// BuildApiUrl combines the base URL with a specific API endpoint.
-func BuildApiUrl(endpoint string) (string, error) {
+// BuildAPIURL combines the base URL with a specific API endpoint.
+func BuildAPIURL(endpoint string) (string, error) {
 	baseUrl, err := GetBaseURL()
 	if err != nil {
 		return "", err

--- a/cmd/utils/httpclient.go
+++ b/cmd/utils/httpclient.go
@@ -75,7 +75,7 @@ func (c *Client) SetBaseBackoff(d time.Duration) {
 
 // GetJSON performs a GET request and unmarshals the JSON response into target.
 func (c *Client) GetJSON(endpoint string, target interface{}) error {
-	url, err := BuildApiUrl(endpoint)
+	url, err := BuildAPIURL(endpoint)
 	if err != nil {
 		return fmt.Errorf("failed to build API URL: %w", err)
 	}
@@ -92,7 +92,7 @@ func (c *Client) GetJSON(endpoint string, target interface{}) error {
 // If body is nil, sends an empty POST request.
 // If target is nil, response body is not unmarshaled.
 func (c *Client) PostJSON(endpoint string, body interface{}, target interface{}) error {
-	url, err := BuildApiUrl(endpoint)
+	url, err := BuildAPIURL(endpoint)
 	if err != nil {
 		return fmt.Errorf("failed to build API URL: %w", err)
 	}


### PR DESCRIPTION
## Summary
- Renamed `BuildApiUrl` to `BuildAPIURL` to follow Go naming conventions for common initialisms (API, URL should be all uppercase)
- Updated all call sites in `httpclient.go`

## Test plan
- [x] `go build` passes
- [x] `go test ./...` passes (all tests)

Closes #8