### PR TITLE
refactor: extract API endpoints as constants

### DIFF
--- a/cmd/process/listProcesses.go
+++ b/cmd/process/listProcesses.go
@@ -24,7 +24,7 @@ var listProcessesCmd = &cobra.Command{
 func ExecuteListProcesses(client *utils.Client, w io.Writer) error {
 	var processes []utils.Process
 
-	if err := client.GetJSON("/api/v2/process/statuses", &processes); err != nil {
+	if err := client.GetJSON(utils.EndpointProcessStatuses, &processes); err != nil {
 		return fmt.Errorf("failed to fetch process statuses: %w", err)
 	}
 

--- a/cmd/process/list_test.go
+++ b/cmd/process/list_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"ftsctl/cmd/testutil"
+	"ftsctl/cmd/utils"
 )
 
 func TestExecuteListProcesses_Success(t *testing.T) {
@@ -44,8 +45,8 @@ func TestExecuteListProcesses_Success(t *testing.T) {
 				if req.Method != "GET" {
 					t.Errorf("Expected GET method, got: %s", req.Method)
 				}
-				if !strings.HasSuffix(req.URL.Path, "/api/v2/process/statuses") {
-					t.Errorf("Expected path to end with /api/v2/process/statuses, got: %s", req.URL.Path)
+				if !strings.HasSuffix(req.URL.Path, utils.EndpointProcessStatuses) {
+					t.Errorf("Expected path to end with %s, got: %s", utils.EndpointProcessStatuses, req.URL.Path)
 				}
 				return h.MockResponse(200, tt.response), nil
 			}

--- a/cmd/process/processStatus.go
+++ b/cmd/process/processStatus.go
@@ -25,7 +25,7 @@ var StatusCmd = &cobra.Command{
 func ExecuteProcessStatus(client *utils.Client, w io.Writer, procId string) error {
 	var prcss utils.Process
 
-	if err := client.GetJSON("/api/v2/process/status/"+procId, &prcss); err != nil {
+	if err := client.GetJSON(utils.EndpointProcessStatus(procId), &prcss); err != nil {
 		return fmt.Errorf("failed to fetch status for process %q: %w", procId, err)
 	}
 

--- a/cmd/process/status_test.go
+++ b/cmd/process/status_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"ftsctl/cmd/testutil"
+	"ftsctl/cmd/utils"
 )
 
 func TestExecuteProcessStatus_Success(t *testing.T) {
@@ -50,8 +51,9 @@ func TestExecuteProcessStatus_Success(t *testing.T) {
 				if req.Method != "GET" {
 					t.Errorf("Expected GET method, got: %s", req.Method)
 				}
-				if !strings.Contains(req.URL.Path, "/api/v2/process/status/") {
-					t.Errorf("Expected path to contain /api/v2/process/status/, got: %s", req.URL.Path)
+				expectedPath := utils.EndpointProcessStatus(tt.processID)
+				if !strings.Contains(req.URL.Path, expectedPath) {
+					t.Errorf("Expected path to contain %s, got: %s", expectedPath, req.URL.Path)
 				}
 				if !strings.HasSuffix(req.URL.Path, tt.processID) {
 					t.Errorf("Expected path to end with %s, got: %s", tt.processID, req.URL.Path)

--- a/cmd/project/config_test.go
+++ b/cmd/project/config_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"ftsctl/cmd/testutil"
+	"ftsctl/cmd/utils"
 )
 
 func TestExecuteProjectConfig_Success(t *testing.T) {
@@ -15,8 +16,9 @@ func TestExecuteProjectConfig_Success(t *testing.T) {
 		if req.Method != "GET" {
 			t.Errorf("Expected GET method, got: %s", req.Method)
 		}
-		if !strings.Contains(req.URL.Path, "/api/v2/projects/TestProject") {
-			t.Errorf("Expected path to contain /api/v2/projects/TestProject, got: %s", req.URL.Path)
+		expectedPath := utils.EndpointProjectConfig("TestProject")
+		if !strings.Contains(req.URL.Path, expectedPath) {
+			t.Errorf("Expected path to contain %s, got: %s", expectedPath, req.URL.Path)
 		}
 		return h.MockResponse(200, testutil.SampleProjectConfig), nil
 	}

--- a/cmd/project/listProjects.go
+++ b/cmd/project/listProjects.go
@@ -24,7 +24,7 @@ var ListProjectsCmd = &cobra.Command{
 func ExecuteListProjects(client *utils.Client, w io.Writer) error {
 	var projects []string
 
-	if err := client.GetJSON("/api/v2/projects", &projects); err != nil {
+	if err := client.GetJSON(utils.EndpointProjects, &projects); err != nil {
 		return fmt.Errorf("failed to fetch projects: %w", err)
 	}
 

--- a/cmd/project/list_test.go
+++ b/cmd/project/list_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"ftsctl/cmd/testutil"
+	"ftsctl/cmd/utils"
 )
 
 func TestExecuteListProjects_Success(t *testing.T) {
@@ -49,8 +50,8 @@ func TestExecuteListProjects_Success(t *testing.T) {
 				if req.Method != "GET" {
 					t.Errorf("Expected GET method, got: %s", req.Method)
 				}
-				if !strings.HasSuffix(req.URL.Path, "/api/v2/projects") {
-					t.Errorf("Expected path to end with /api/v2/projects, got: %s", req.URL.Path)
+				if !strings.HasSuffix(req.URL.Path, utils.EndpointProjects) {
+					t.Errorf("Expected path to end with %s, got: %s", utils.EndpointProjects, req.URL.Path)
 				}
 				return h.MockResponse(200, tt.response), nil
 			}

--- a/cmd/project/projectConfig.go
+++ b/cmd/project/projectConfig.go
@@ -96,7 +96,7 @@ var ConfigCmd = &cobra.Command{
 func ExecuteProjectConfig(client *utils.Client, w io.Writer, projectName string) error {
 	var pConfig Config
 
-	if err := client.GetJSON("/api/v2/projects/"+projectName, &pConfig); err != nil {
+	if err := client.GetJSON(utils.EndpointProjectConfig(projectName), &pConfig); err != nil {
 		return fmt.Errorf("failed to fetch configuration for project %q: %w", projectName, err)
 	}
 

--- a/cmd/transfer/startTransfer.go
+++ b/cmd/transfer/startTransfer.go
@@ -35,7 +35,7 @@ patients for the specified project.`,
 // If ids is empty/nil, transfers all consented patients.
 // This function is exported for testing.
 func ExecuteStartTransfer(client *utils.Client, w io.Writer, projectName string, ids []string) error {
-	endpoint := fmt.Sprintf("/api/v2/process/%s/start", projectName)
+	endpoint := utils.EndpointTransferStart(projectName)
 
 	var body interface{}
 	if len(ids) > 0 {

--- a/cmd/transfer/start_test.go
+++ b/cmd/transfer/start_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"ftsctl/cmd/testutil"
+	"ftsctl/cmd/utils"
 )
 
 func TestExecuteStartTransfer_Success(t *testing.T) {
@@ -182,7 +183,7 @@ func TestExecuteStartTransfer_ProjectNameInURL(t *testing.T) {
 
 			_ = ExecuteStartTransfer(h.Client, h.Stdout, tt.projectName, nil)
 
-			expectedPath := "/api/v2/process/" + tt.projectName + "/start"
+			expectedPath := utils.EndpointTransferStart(tt.projectName)
 			if !strings.HasSuffix(capturedPath, expectedPath) {
 				t.Errorf("Expected URL path to end with %q, got: %s", expectedPath, capturedPath)
 			}

--- a/cmd/utils/endpoints.go
+++ b/cmd/utils/endpoints.go
@@ -1,0 +1,30 @@
+package utils
+
+// API v2 endpoint constants for static paths.
+const (
+	// EndpointProjects is the endpoint for listing all projects.
+	// GET /api/v2/projects
+	EndpointProjects = "/api/v2/projects"
+
+	// EndpointProcessStatuses is the endpoint for listing all process statuses.
+	// GET /api/v2/process/statuses
+	EndpointProcessStatuses = "/api/v2/process/statuses"
+)
+
+// EndpointProjectConfig returns the endpoint for fetching a specific project configuration.
+// GET /api/v2/projects/{projectName}
+func EndpointProjectConfig(projectName string) string {
+	return "/api/v2/projects/" + projectName
+}
+
+// EndpointProcessStatus returns the endpoint for fetching a specific process status.
+// GET /api/v2/process/status/{processID}
+func EndpointProcessStatus(processID string) string {
+	return "/api/v2/process/status/" + processID
+}
+
+// EndpointTransferStart returns the endpoint for starting a transfer for a project.
+// POST /api/v2/process/{projectName}/start
+func EndpointTransferStart(projectName string) string {
+	return "/api/v2/process/" + projectName + "/start"
+}

--- a/cmd/utils/endpoints_test.go
+++ b/cmd/utils/endpoints_test.go
@@ -1,0 +1,86 @@
+package utils
+
+import (
+	"testing"
+)
+
+func TestEndpointConstants(t *testing.T) {
+	tests := []struct {
+		name     string
+		constant string
+		expected string
+	}{
+		{"projects endpoint", EndpointProjects, "/api/v2/projects"},
+		{"process statuses endpoint", EndpointProcessStatuses, "/api/v2/process/statuses"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.constant != tt.expected {
+				t.Errorf("Expected %q, got %q", tt.expected, tt.constant)
+			}
+		})
+	}
+}
+
+func TestEndpointProjectConfig(t *testing.T) {
+	tests := []struct {
+		name        string
+		projectName string
+		wantPath    string
+	}{
+		{"valid project name", "MyProject", "/api/v2/projects/MyProject"},
+		{"project with dash", "my-project", "/api/v2/projects/my-project"},
+		{"project with numbers", "project123", "/api/v2/projects/project123"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := EndpointProjectConfig(tt.projectName)
+			if got != tt.wantPath {
+				t.Errorf("Expected path %q, got %q", tt.wantPath, got)
+			}
+		})
+	}
+}
+
+func TestEndpointProcessStatus(t *testing.T) {
+	tests := []struct {
+		name      string
+		processID string
+		wantPath  string
+	}{
+		{"valid process ID", "proc-123", "/api/v2/process/status/proc-123"},
+		{"UUID process ID", "550e8400-e29b-41d4-a716-446655440000", "/api/v2/process/status/550e8400-e29b-41d4-a716-446655440000"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := EndpointProcessStatus(tt.processID)
+			if got != tt.wantPath {
+				t.Errorf("Expected path %q, got %q", tt.wantPath, got)
+			}
+		})
+	}
+}
+
+func TestEndpointTransferStart(t *testing.T) {
+	tests := []struct {
+		name        string
+		projectName string
+		wantPath    string
+	}{
+		{"valid project name", "TestProject", "/api/v2/process/TestProject/start"},
+		{"project with dash", "my-project", "/api/v2/process/my-project/start"},
+		{"project with numbers", "project123", "/api/v2/process/project123/start"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := EndpointTransferStart(tt.projectName)
+			if got != tt.wantPath {
+				t.Errorf("Expected path %q, got %q", tt.wantPath, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Create centralized endpoint definitions in `cmd/utils/endpoints.go`
- Replace hardcoded API endpoint strings with constants and helper functions
- Update both implementation and test files to use the same endpoint definitions

## Changes
- **New files:**
  - `cmd/utils/endpoints.go` - Endpoint constants and helper functions
  - `cmd/utils/endpoints_test.go` - Unit tests for endpoint functions

- **Modified files:**
  - `cmd/project/listProjects.go` - Use `utils.EndpointProjects` constant
  - `cmd/project/projectConfig.go` - Use `utils.EndpointProjectConfig()` function
  - `cmd/process/listProcesses.go` - Use `utils.EndpointProcessStatuses` constant
  - `cmd/process/processStatus.go` - Use `utils.EndpointProcessStatus()` function
  - `cmd/transfer/startTransfer.go` - Use `utils.EndpointTransferStart()` function
  - Test files updated to use same constants for assertions

## Test plan
- [x] All existing tests pass
- [x] New endpoint unit tests pass
- [x] Build succeeds

Closes #5