### PR TITLE
feat: add context.Context support to HTTP client

### DIFF
--- a/cmd/process/listProcesses.go
+++ b/cmd/process/listProcesses.go
@@ -1,6 +1,7 @@
 package process
 
 import (
+	"context"
 	"fmt"
 	"io"
 
@@ -24,7 +25,7 @@ var listProcessesCmd = &cobra.Command{
 func ExecuteListProcesses(client *utils.Client, w io.Writer) error {
 	var processes []utils.Process
 
-	if err := client.GetJSON(utils.EndpointProcessStatuses, &processes); err != nil {
+	if err := client.GetJSON(context.Background(), utils.EndpointProcessStatuses, &processes); err != nil {
 		return fmt.Errorf("failed to fetch process statuses: %w", err)
 	}
 

--- a/cmd/process/processStatus.go
+++ b/cmd/process/processStatus.go
@@ -1,6 +1,7 @@
 package process
 
 import (
+	"context"
 	"fmt"
 	"io"
 
@@ -25,7 +26,7 @@ var StatusCmd = &cobra.Command{
 func ExecuteProcessStatus(client *utils.Client, w io.Writer, procId string) error {
 	var prcss utils.Process
 
-	if err := client.GetJSON(utils.EndpointProcessStatus(procId), &prcss); err != nil {
+	if err := client.GetJSON(context.Background(), utils.EndpointProcessStatus(procId), &prcss); err != nil {
 		return fmt.Errorf("failed to fetch status for process %q: %w", procId, err)
 	}
 

--- a/cmd/project/listProjects.go
+++ b/cmd/project/listProjects.go
@@ -1,6 +1,7 @@
 package project
 
 import (
+	"context"
 	"fmt"
 	"io"
 
@@ -24,7 +25,7 @@ var ListProjectsCmd = &cobra.Command{
 func ExecuteListProjects(client *utils.Client, w io.Writer) error {
 	var projects []string
 
-	if err := client.GetJSON(utils.EndpointProjects, &projects); err != nil {
+	if err := client.GetJSON(context.Background(), utils.EndpointProjects, &projects); err != nil {
 		return fmt.Errorf("failed to fetch projects: %w", err)
 	}
 

--- a/cmd/project/projectConfig.go
+++ b/cmd/project/projectConfig.go
@@ -1,6 +1,7 @@
 package project
 
 import (
+	"context"
 	"fmt"
 	"io"
 
@@ -96,7 +97,7 @@ var ConfigCmd = &cobra.Command{
 func ExecuteProjectConfig(client *utils.Client, w io.Writer, projectName string) error {
 	var pConfig Config
 
-	if err := client.GetJSON(utils.EndpointProjectConfig(projectName), &pConfig); err != nil {
+	if err := client.GetJSON(context.Background(), utils.EndpointProjectConfig(projectName), &pConfig); err != nil {
 		return fmt.Errorf("failed to fetch configuration for project %q: %w", projectName, err)
 	}
 

--- a/cmd/transfer/startTransfer.go
+++ b/cmd/transfer/startTransfer.go
@@ -1,6 +1,7 @@
 package transfer
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"log/slog"
@@ -42,7 +43,7 @@ func ExecuteStartTransfer(client *utils.Client, w io.Writer, projectName string,
 		body = ids
 	}
 
-	if err := client.PostJSON(endpoint, body, nil); err != nil {
+	if err := client.PostJSON(context.Background(), endpoint, body, nil); err != nil {
 		return fmt.Errorf("failed to start transfer for project %q: %w", projectName, err)
 	}
 

--- a/cmd/utils/httpclient.go
+++ b/cmd/utils/httpclient.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -74,24 +75,26 @@ func (c *Client) SetBaseBackoff(d time.Duration) {
 }
 
 // GetJSON performs a GET request and unmarshals the JSON response into target.
-func (c *Client) GetJSON(endpoint string, target interface{}) error {
+// The context controls cancellation and timeouts for the request.
+func (c *Client) GetJSON(ctx context.Context, endpoint string, target interface{}) error {
 	url, err := BuildAPIURL(endpoint)
 	if err != nil {
 		return fmt.Errorf("failed to build API URL: %w", err)
 	}
 
-	req, err := http.NewRequest("GET", url, nil)
+	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
 	if err != nil {
 		return fmt.Errorf("failed to create request: %w", err)
 	}
 
-	return c.doWithRetry(req, target)
+	return c.doWithRetry(ctx, req, target)
 }
 
 // PostJSON performs a POST request with optional JSON body and unmarshals the response.
 // If body is nil, sends an empty POST request.
 // If target is nil, response body is not unmarshaled.
-func (c *Client) PostJSON(endpoint string, body interface{}, target interface{}) error {
+// The context controls cancellation and timeouts for the request.
+func (c *Client) PostJSON(ctx context.Context, endpoint string, body interface{}, target interface{}) error {
 	url, err := BuildAPIURL(endpoint)
 	if err != nil {
 		return fmt.Errorf("failed to build API URL: %w", err)
@@ -109,7 +112,7 @@ func (c *Client) PostJSON(endpoint string, body interface{}, target interface{})
 		bodyReader = bytes.NewReader(jsonData)
 	}
 
-	req, err := http.NewRequest("POST", url, bodyReader)
+	req, err := http.NewRequestWithContext(ctx, "POST", url, bodyReader)
 	if err != nil {
 		return fmt.Errorf("failed to create request: %w", err)
 	}
@@ -122,18 +125,30 @@ func (c *Client) PostJSON(endpoint string, body interface{}, target interface{})
 		}
 	}
 
-	return c.doWithRetry(req, target)
+	return c.doWithRetry(ctx, req, target)
 }
 
 // doWithRetry executes the request with exponential backoff retry logic.
-func (c *Client) doWithRetry(req *http.Request, target interface{}) error {
+// It respects context cancellation and will abort retries if the context is done.
+func (c *Client) doWithRetry(ctx context.Context, req *http.Request, target interface{}) error {
 	var lastErr error
 
 	for attempt := 1; attempt <= c.maxRetries; attempt++ {
+		// Check context before each attempt
+		if err := ctx.Err(); err != nil {
+			return fmt.Errorf("request cancelled: %w", err)
+		}
+
 		if attempt > 1 {
 			backoff := c.calculateBackoff(attempt - 1)
 			slog.Debug("Retrying request", "attempt", attempt, "backoff", backoff, "url", req.URL.String())
-			time.Sleep(backoff)
+
+			// Use select to allow context cancellation during backoff
+			select {
+			case <-ctx.Done():
+				return fmt.Errorf("request cancelled during retry backoff: %w", ctx.Err())
+			case <-time.After(backoff):
+			}
 
 			// Recreate body reader for retry if needed
 			if req.GetBody != nil {

--- a/cmd/utils/httpclient_test.go
+++ b/cmd/utils/httpclient_test.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"io"
 	"net/http"
@@ -53,7 +54,7 @@ func TestClient_GetJSON_Success(t *testing.T) {
 	client := NewClientWithHTTPClient(mockClient)
 	var projects []string
 
-	err := client.GetJSON("/api/v2/projects", &projects)
+	err := client.GetJSON(context.Background(), "/api/v2/projects", &projects)
 	if err != nil {
 		t.Fatalf("Expected no error, got: %v", err)
 	}
@@ -77,7 +78,7 @@ func TestClient_GetJSON_EmptyResponse(t *testing.T) {
 	client := NewClientWithHTTPClient(mockClient)
 	var result interface{}
 
-	err := client.GetJSON("/api/v2/test", &result)
+	err := client.GetJSON(context.Background(), "/api/v2/test", &result)
 	if err != nil {
 		t.Fatalf("Expected no error for empty response, got: %v", err)
 	}
@@ -93,7 +94,7 @@ func TestClient_GetJSON_HTTPError(t *testing.T) {
 	client := NewClientWithHTTPClient(mockClient)
 	var result interface{}
 
-	err := client.GetJSON("/api/v2/test", &result)
+	err := client.GetJSON(context.Background(), "/api/v2/test", &result)
 	if err == nil {
 		t.Fatal("Expected error for 404 response")
 	}
@@ -129,7 +130,7 @@ func TestClient_PostJSON_Success(t *testing.T) {
 	payload := map[string]string{"key": "value"}
 	var result map[string]bool
 
-	err := client.PostJSON("/api/v2/test", payload, &result)
+	err := client.PostJSON(context.Background(), "/api/v2/test", payload, &result)
 	if err != nil {
 		t.Fatalf("Expected no error, got: %v", err)
 	}
@@ -155,7 +156,7 @@ func TestClient_PostJSON_NilBody(t *testing.T) {
 
 	client := NewClientWithHTTPClient(mockClient)
 
-	err := client.PostJSON("/api/v2/test", nil, nil)
+	err := client.PostJSON(context.Background(), "/api/v2/test", nil, nil)
 	if err != nil {
 		t.Fatalf("Expected no error, got: %v", err)
 	}
@@ -170,7 +171,7 @@ func TestClient_PostJSON_AcceptedStatus(t *testing.T) {
 
 	client := NewClientWithHTTPClient(mockClient)
 
-	err := client.PostJSON("/api/v2/test", nil, nil)
+	err := client.PostJSON(context.Background(), "/api/v2/test", nil, nil)
 	if err != nil {
 		t.Fatalf("Expected no error for 202 Accepted, got: %v", err)
 	}
@@ -194,7 +195,7 @@ func TestClient_Retry_OnNetworkError(t *testing.T) {
 	client.baseBackoff = 10 * time.Millisecond // Speed up test
 	var result map[string]bool
 
-	err := client.GetJSON("/api/v2/test", &result)
+	err := client.GetJSON(context.Background(), "/api/v2/test", &result)
 	if err != nil {
 		t.Fatalf("Expected success after retries, got: %v", err)
 	}
@@ -222,7 +223,7 @@ func TestClient_Retry_OnServerError(t *testing.T) {
 	client.baseBackoff = 10 * time.Millisecond // Speed up test
 	var result map[string]bool
 
-	err := client.GetJSON("/api/v2/test", &result)
+	err := client.GetJSON(context.Background(), "/api/v2/test", &result)
 	if err != nil {
 		t.Fatalf("Expected success after retries, got: %v", err)
 	}
@@ -246,7 +247,7 @@ func TestClient_NoRetry_OnClientError(t *testing.T) {
 	client.baseBackoff = 10 * time.Millisecond
 	var result interface{}
 
-	err := client.GetJSON("/api/v2/test", &result)
+	err := client.GetJSON(context.Background(), "/api/v2/test", &result)
 	if err == nil {
 		t.Fatal("Expected error for 400 response")
 	}
@@ -271,7 +272,7 @@ func TestClient_MaxRetries_Exceeded(t *testing.T) {
 	client.baseBackoff = 10 * time.Millisecond
 	var result interface{}
 
-	err := client.GetJSON("/api/v2/test", &result)
+	err := client.GetJSON(context.Background(), "/api/v2/test", &result)
 	if err == nil {
 		t.Fatal("Expected error after max retries")
 	}
@@ -361,8 +362,8 @@ func TestClient_Integration_WithHTTPTestServer(t *testing.T) {
 	t.Run("GET projects", func(t *testing.T) {
 		var projects []string
 		// Note: We need to build URL manually for test server
-		req, _ := http.NewRequest("GET", server.URL+"/api/v2/projects", nil)
-		err := client.doWithRetry(req, &projects)
+		req, _ := http.NewRequestWithContext(context.Background(), "GET", server.URL+"/api/v2/projects", nil)
+		err := client.doWithRetry(context.Background(), req, &projects)
 		if err != nil {
 			t.Fatalf("Expected no error, got: %v", err)
 		}
@@ -372,10 +373,137 @@ func TestClient_Integration_WithHTTPTestServer(t *testing.T) {
 	})
 
 	t.Run("POST start process", func(t *testing.T) {
-		req, _ := http.NewRequest("POST", server.URL+"/api/v2/process/start", nil)
-		err := client.doWithRetry(req, nil)
+		req, _ := http.NewRequestWithContext(context.Background(), "POST", server.URL+"/api/v2/process/start", nil)
+		err := client.doWithRetry(context.Background(), req, nil)
 		if err != nil {
 			t.Fatalf("Expected no error for 202 response, got: %v", err)
 		}
 	})
+}
+
+// Context cancellation tests
+
+func TestClient_GetJSON_ContextCancelled(t *testing.T) {
+	mockClient := &MockHTTPClient{
+		DoFunc: func(req *http.Request) (*http.Response, error) {
+			// Simulate a slow request that respects context
+			select {
+			case <-req.Context().Done():
+				return nil, req.Context().Err()
+			case <-time.After(100 * time.Millisecond):
+				return newMockResponse(200, `{"success": true}`), nil
+			}
+		},
+	}
+
+	client := NewClientWithHTTPClient(mockClient)
+
+	// Create a context that's already cancelled
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	var result interface{}
+	err := client.GetJSON(ctx, "/api/v2/test", &result)
+	if err == nil {
+		t.Fatal("Expected error for cancelled context")
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("Expected context.Canceled error, got: %v", err)
+	}
+}
+
+func TestClient_GetJSON_ContextTimeout(t *testing.T) {
+	mockClient := &MockHTTPClient{
+		DoFunc: func(req *http.Request) (*http.Response, error) {
+			// Simulate a slow request
+			select {
+			case <-req.Context().Done():
+				return nil, req.Context().Err()
+			case <-time.After(200 * time.Millisecond):
+				return newMockResponse(200, `{"success": true}`), nil
+			}
+		},
+	}
+
+	client := NewClientWithHTTPClient(mockClient)
+
+	// Create a context with a short timeout
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	var result interface{}
+	err := client.GetJSON(ctx, "/api/v2/test", &result)
+	if err == nil {
+		t.Fatal("Expected error for context timeout")
+	}
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Errorf("Expected context.DeadlineExceeded error, got: %v", err)
+	}
+}
+
+func TestClient_Retry_ContextCancelledDuringBackoff(t *testing.T) {
+	var attempts int32
+
+	mockClient := &MockHTTPClient{
+		DoFunc: func(req *http.Request) (*http.Response, error) {
+			atomic.AddInt32(&attempts, 1)
+			// Always fail to trigger retry
+			return nil, errors.New("network error")
+		},
+	}
+
+	client := NewClientWithHTTPClient(mockClient)
+	client.baseBackoff = 100 * time.Millisecond // Long enough backoff to cancel during
+
+	// Create a context that we'll cancel after the first attempt
+	ctx, cancel := context.WithCancel(context.Background())
+
+	// Cancel context after a short delay (after first attempt but during backoff)
+	go func() {
+		time.Sleep(20 * time.Millisecond)
+		cancel()
+	}()
+
+	var result interface{}
+	err := client.GetJSON(ctx, "/api/v2/test", &result)
+	if err == nil {
+		t.Fatal("Expected error when context cancelled during backoff")
+	}
+
+	// Should have only made 1 attempt before context was cancelled during backoff
+	if atomic.LoadInt32(&attempts) != 1 {
+		t.Errorf("Expected 1 attempt before cancel, got: %d", attempts)
+	}
+
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("Expected context.Canceled error, got: %v", err)
+	}
+}
+
+func TestClient_PostJSON_ContextCancelled(t *testing.T) {
+	mockClient := &MockHTTPClient{
+		DoFunc: func(req *http.Request) (*http.Response, error) {
+			select {
+			case <-req.Context().Done():
+				return nil, req.Context().Err()
+			case <-time.After(100 * time.Millisecond):
+				return newMockResponse(200, `{"success": true}`), nil
+			}
+		},
+	}
+
+	client := NewClientWithHTTPClient(mockClient)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	payload := map[string]string{"key": "value"}
+	var result map[string]bool
+	err := client.PostJSON(ctx, "/api/v2/test", payload, &result)
+	if err == nil {
+		t.Fatal("Expected error for cancelled context")
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("Expected context.Canceled error, got: %v", err)
+	}
 }


### PR DESCRIPTION
## Summary

- Add `context.Context` as the first parameter to `GetJSON` and `PostJSON` methods
- Implement context cancellation checks before each retry attempt
- Use `select` with `ctx.Done()` during backoff for immediate cancellation response
- Update all command callers to pass `context.Background()`
- Add comprehensive tests for context cancellation and timeout scenarios

## Test plan

- [x] All existing tests pass
- [x] New tests added for context cancellation
- [x] New tests added for context timeout
- [x] New tests added for cancellation during retry backoff
- [x] Verified `go test -v ./...` passes

Closes #9