### PR TITLE
feat: add custom headers support to HTTP client

### DIFF
--- a/cmd/utils/httpclient.go
+++ b/cmd/utils/httpclient.go
@@ -23,6 +23,7 @@ type Client struct {
 	httpClient  HTTPClient
 	maxRetries  int
 	baseBackoff time.Duration
+	headers     http.Header
 }
 
 // testClient is used for testing to inject a mock client.
@@ -43,6 +44,7 @@ func NewClient() *Client {
 		},
 		maxRetries:  3,
 		baseBackoff: 1 * time.Second,
+		headers:     make(http.Header),
 	}
 }
 
@@ -65,13 +67,101 @@ func NewClientWithHTTPClient(httpClient HTTPClient) *Client {
 		httpClient:  httpClient,
 		maxRetries:  3,
 		baseBackoff: 1 * time.Second,
+		headers:     make(http.Header),
 	}
 }
 
 // SetBaseBackoff sets the base backoff duration for retries.
 // This is primarily useful in tests to speed up retry scenarios.
+//
+// Deprecated: Use WithBaseBackoff instead for immutable configuration.
+// This method mutates the client and is not safe for concurrent use.
 func (c *Client) SetBaseBackoff(d time.Duration) {
 	c.baseBackoff = d
+}
+
+// copyHeaders creates a deep copy of http.Header.
+// This ensures immutability when creating new Client instances.
+func copyHeaders(src http.Header) http.Header {
+	if src == nil {
+		return make(http.Header)
+	}
+	dst := make(http.Header, len(src))
+	for k, v := range src {
+		dst[k] = append([]string(nil), v...)
+	}
+	return dst
+}
+
+// clone creates a shallow copy of the Client with independent headers.
+// The underlying httpClient is shared (which is safe since http.Client is thread-safe).
+func (c *Client) clone() *Client {
+	return &Client{
+		httpClient:  c.httpClient,
+		maxRetries:  c.maxRetries,
+		baseBackoff: c.baseBackoff,
+		headers:     copyHeaders(c.headers),
+	}
+}
+
+// WithHeader returns a new Client with the specified header added.
+// If the header already exists, it replaces the value.
+// Returns a new Client; does not modify the receiver.
+func (c *Client) WithHeader(key, value string) *Client {
+	newClient := c.clone()
+	newClient.headers.Set(key, value)
+	return newClient
+}
+
+// WithHeaders returns a new Client with multiple headers added.
+// Existing headers with the same keys will be replaced.
+// Returns a new Client; does not modify the receiver.
+func (c *Client) WithHeaders(headers map[string]string) *Client {
+	newClient := c.clone()
+	for k, v := range headers {
+		newClient.headers.Set(k, v)
+	}
+	return newClient
+}
+
+// WithBearerToken returns a new Client with Bearer token authentication.
+// Sets the Authorization header to "Bearer {token}".
+// Returns a new Client; does not modify the receiver.
+func (c *Client) WithBearerToken(token string) *Client {
+	return c.WithHeader("Authorization", "Bearer "+token)
+}
+
+// WithAPIKey returns a new Client with API key authentication.
+// Sets the X-API-Key header to the provided key.
+// Returns a new Client; does not modify the receiver.
+func (c *Client) WithAPIKey(key string) *Client {
+	return c.WithHeader("X-API-Key", key)
+}
+
+// WithBaseBackoff returns a new Client with the specified base backoff duration.
+// This is primarily useful in tests to speed up retry scenarios.
+// Returns a new Client; does not modify the receiver.
+func (c *Client) WithBaseBackoff(d time.Duration) *Client {
+	newClient := c.clone()
+	newClient.baseBackoff = d
+	return newClient
+}
+
+// applyHeaders copies client-level headers to the request.
+// Does not overwrite headers already set on the request.
+// This preserves request-specific headers like Content-Type.
+func (c *Client) applyHeaders(req *http.Request) {
+	if c.headers == nil || req == nil {
+		return
+	}
+
+	for key, values := range c.headers {
+		if req.Header.Get(key) == "" {
+			for _, value := range values {
+				req.Header.Add(key, value)
+			}
+		}
+	}
 }
 
 // GetJSON performs a GET request and unmarshals the JSON response into target.
@@ -86,6 +176,8 @@ func (c *Client) GetJSON(ctx context.Context, endpoint string, target interface{
 	if err != nil {
 		return fmt.Errorf("failed to create request: %w", err)
 	}
+
+	c.applyHeaders(req)
 
 	return c.doWithRetry(ctx, req, target)
 }
@@ -124,6 +216,8 @@ func (c *Client) PostJSON(ctx context.Context, endpoint string, body interface{}
 			return io.NopCloser(bytes.NewReader(jsonData)), nil
 		}
 	}
+
+	c.applyHeaders(req)
 
 	return c.doWithRetry(ctx, req, target)
 }

--- a/cmd/utils/httpclient_test.go
+++ b/cmd/utils/httpclient_test.go
@@ -507,3 +507,286 @@ func TestClient_PostJSON_ContextCancelled(t *testing.T) {
 		t.Errorf("Expected context.Canceled error, got: %v", err)
 	}
 }
+
+// Builder method tests
+
+func TestClient_WithHeader(t *testing.T) {
+	var capturedHeaders http.Header
+	mockClient := &MockHTTPClient{
+		DoFunc: func(req *http.Request) (*http.Response, error) {
+			capturedHeaders = req.Header
+			return newMockResponse(200, `{"success": true}`), nil
+		},
+	}
+
+	client := NewClientWithHTTPClient(mockClient).
+		WithHeader("X-Custom-Header", "custom-value")
+
+	var result map[string]bool
+	err := client.GetJSON(context.Background(), "/api/v2/test", &result)
+	if err != nil {
+		t.Fatalf("Expected no error, got: %v", err)
+	}
+
+	if capturedHeaders.Get("X-Custom-Header") != "custom-value" {
+		t.Errorf("Expected X-Custom-Header to be 'custom-value', got: %s",
+			capturedHeaders.Get("X-Custom-Header"))
+	}
+}
+
+func TestClient_WithHeaders(t *testing.T) {
+	var capturedHeaders http.Header
+	mockClient := &MockHTTPClient{
+		DoFunc: func(req *http.Request) (*http.Response, error) {
+			capturedHeaders = req.Header
+			return newMockResponse(200, `{"success": true}`), nil
+		},
+	}
+
+	headers := map[string]string{
+		"X-Header-1": "value1",
+		"X-Header-2": "value2",
+	}
+	client := NewClientWithHTTPClient(mockClient).WithHeaders(headers)
+
+	var result map[string]bool
+	err := client.GetJSON(context.Background(), "/api/v2/test", &result)
+	if err != nil {
+		t.Fatalf("Expected no error, got: %v", err)
+	}
+
+	if capturedHeaders.Get("X-Header-1") != "value1" {
+		t.Errorf("Expected X-Header-1 to be 'value1', got: %s",
+			capturedHeaders.Get("X-Header-1"))
+	}
+	if capturedHeaders.Get("X-Header-2") != "value2" {
+		t.Errorf("Expected X-Header-2 to be 'value2', got: %s",
+			capturedHeaders.Get("X-Header-2"))
+	}
+}
+
+func TestClient_WithBearerToken(t *testing.T) {
+	var capturedHeaders http.Header
+	mockClient := &MockHTTPClient{
+		DoFunc: func(req *http.Request) (*http.Response, error) {
+			capturedHeaders = req.Header
+			return newMockResponse(200, `{"success": true}`), nil
+		},
+	}
+
+	client := NewClientWithHTTPClient(mockClient).
+		WithBearerToken("secret-token-123")
+
+	var result map[string]bool
+	err := client.GetJSON(context.Background(), "/api/v2/test", &result)
+	if err != nil {
+		t.Fatalf("Expected no error, got: %v", err)
+	}
+
+	expected := "Bearer secret-token-123"
+	if capturedHeaders.Get("Authorization") != expected {
+		t.Errorf("Expected Authorization to be '%s', got: %s",
+			expected, capturedHeaders.Get("Authorization"))
+	}
+}
+
+func TestClient_WithAPIKey(t *testing.T) {
+	var capturedHeaders http.Header
+	mockClient := &MockHTTPClient{
+		DoFunc: func(req *http.Request) (*http.Response, error) {
+			capturedHeaders = req.Header
+			return newMockResponse(200, `{"success": true}`), nil
+		},
+	}
+
+	client := NewClientWithHTTPClient(mockClient).
+		WithAPIKey("api-key-456")
+
+	var result map[string]bool
+	err := client.GetJSON(context.Background(), "/api/v2/test", &result)
+	if err != nil {
+		t.Fatalf("Expected no error, got: %v", err)
+	}
+
+	if capturedHeaders.Get("X-API-Key") != "api-key-456" {
+		t.Errorf("Expected X-API-Key to be 'api-key-456', got: %s",
+			capturedHeaders.Get("X-API-Key"))
+	}
+}
+
+func TestClient_ImmutableHeaders(t *testing.T) {
+	baseClient := NewClientWithHTTPClient(&MockHTTPClient{
+		DoFunc: func(req *http.Request) (*http.Response, error) {
+			return newMockResponse(200, `{}`), nil
+		},
+	})
+
+	derivedClient := baseClient.WithHeader("X-Test", "value")
+
+	if len(baseClient.headers) != 0 {
+		t.Error("Base client was modified - immutability violated")
+	}
+
+	if derivedClient.headers.Get("X-Test") != "value" {
+		t.Error("Derived client should have the header")
+	}
+}
+
+func TestClient_ChainedHeaders(t *testing.T) {
+	var capturedHeaders http.Header
+	mockClient := &MockHTTPClient{
+		DoFunc: func(req *http.Request) (*http.Response, error) {
+			capturedHeaders = req.Header
+			return newMockResponse(200, `{}`), nil
+		},
+	}
+
+	client := NewClientWithHTTPClient(mockClient).
+		WithHeader("X-Header-1", "value1").
+		WithHeader("X-Header-2", "value2").
+		WithBearerToken("token")
+
+	err := client.GetJSON(context.Background(), "/api/v2/test", nil)
+	if err != nil {
+		t.Fatalf("Expected no error, got: %v", err)
+	}
+
+	if capturedHeaders.Get("X-Header-1") != "value1" {
+		t.Error("First header not applied")
+	}
+	if capturedHeaders.Get("X-Header-2") != "value2" {
+		t.Error("Second header not applied")
+	}
+	if capturedHeaders.Get("Authorization") != "Bearer token" {
+		t.Error("Bearer token not applied")
+	}
+}
+
+func TestClient_HeadersAppliedToRetries(t *testing.T) {
+	var attemptHeaders []http.Header
+	mockClient := &MockHTTPClient{
+		DoFunc: func(req *http.Request) (*http.Response, error) {
+			headerCopy := make(http.Header)
+			for key, values := range req.Header {
+				headerCopy[key] = append([]string(nil), values...)
+			}
+			attemptHeaders = append(attemptHeaders, headerCopy)
+
+			if len(attemptHeaders) < 2 {
+				return nil, errors.New("network error")
+			}
+			return newMockResponse(200, `{}`), nil
+		},
+	}
+
+	client := NewClientWithHTTPClient(mockClient).
+		WithHeader("X-Custom", "value")
+	client.SetBaseBackoff(10 * time.Millisecond)
+
+	err := client.GetJSON(context.Background(), "/api/v2/test", nil)
+	if err != nil {
+		t.Fatalf("Expected success after retry, got: %v", err)
+	}
+
+	if len(attemptHeaders) != 2 {
+		t.Fatalf("Expected 2 attempts, got: %d", len(attemptHeaders))
+	}
+
+	for i, headers := range attemptHeaders {
+		if headers.Get("X-Custom") != "value" {
+			t.Errorf("Header missing in attempt %d", i+1)
+		}
+	}
+}
+
+func TestClient_HeadersNotOverwriteRequestHeaders(t *testing.T) {
+	mockClient := &MockHTTPClient{
+		DoFunc: func(req *http.Request) (*http.Response, error) {
+			if req.Header.Get("Content-Type") != "application/json" {
+				t.Errorf("Request Content-Type should not be overwritten, got: %s",
+					req.Header.Get("Content-Type"))
+			}
+			if req.Header.Get("X-Custom") != "value" {
+				t.Error("Custom header should be applied")
+			}
+			return newMockResponse(200, `{}`), nil
+		},
+	}
+
+	client := NewClientWithHTTPClient(mockClient).
+		WithHeader("Content-Type", "text/plain").
+		WithHeader("X-Custom", "value")
+
+	payload := map[string]string{"key": "value"}
+	var result map[string]interface{}
+	err := client.PostJSON(context.Background(), "/api/v2/test", payload, &result)
+	if err != nil {
+		t.Fatalf("Expected no error, got: %v", err)
+	}
+}
+
+func TestClient_CopyHeaders_DeepCopy(t *testing.T) {
+	original := make(http.Header)
+	original.Set("X-Original", "value1")
+	original.Add("X-Multi", "value1")
+	original.Add("X-Multi", "value2")
+
+	copied := copyHeaders(original)
+
+	copied.Set("X-Original", "modified")
+	copied.Set("X-New", "newvalue")
+	copied.Add("X-Multi", "value3")
+
+	if original.Get("X-Original") != "value1" {
+		t.Error("Original header was modified")
+	}
+	if original.Get("X-New") != "" {
+		t.Error("Original should not have new header")
+	}
+	if len(original["X-Multi"]) != 2 {
+		t.Error("Original multi-value header was modified")
+	}
+}
+
+func TestClient_WithBaseBackoff_Immutable(t *testing.T) {
+	client := NewClient()
+	originalBackoff := client.baseBackoff
+
+	clientWithNewBackoff := client.WithBaseBackoff(5 * time.Second)
+
+	if client.baseBackoff != originalBackoff {
+		t.Error("Original client baseBackoff was mutated")
+	}
+
+	if clientWithNewBackoff.baseBackoff != 5*time.Second {
+		t.Error("New client should have updated baseBackoff")
+	}
+}
+
+func TestClient_HeadersInPostJSON(t *testing.T) {
+	mockClient := &MockHTTPClient{
+		DoFunc: func(req *http.Request) (*http.Response, error) {
+			if req.Header.Get("X-Trace-ID") != "trace-123" {
+				t.Error("Custom header not applied to POST request")
+			}
+			if req.Header.Get("Content-Type") != "application/json" {
+				t.Error("Content-Type should be application/json for POST with body")
+			}
+			return newMockResponse(201, `{"id": 42}`), nil
+		},
+	}
+
+	client := NewClientWithHTTPClient(mockClient).
+		WithHeader("X-Trace-ID", "trace-123")
+
+	payload := map[string]string{"name": "test"}
+	var result map[string]int
+	err := client.PostJSON(context.Background(), "/api/v2/test", payload, &result)
+	if err != nil {
+		t.Fatalf("Expected no error, got: %v", err)
+	}
+
+	if result["id"] != 42 {
+		t.Errorf("Expected id=42, got: %d", result["id"])
+	}
+}


### PR DESCRIPTION
## Summary

- Add immutable builder methods for custom headers: `WithHeader()`, `WithHeaders()`, `WithBearerToken()`, `WithAPIKey()`
- Add `WithBaseBackoff()` as immutable alternative to deprecated `SetBaseBackoff()`
- Headers applied to all requests without overwriting request-specific headers (e.g., Content-Type)
- Implementation ensures immutability via deep copying - original client is never modified

## Usage

```go
client := utils.NewClient().
    WithBearerToken(os.Getenv("API_TOKEN")).
    WithHeader("X-Request-ID", uuid.New().String())
```

## Test plan

- [x] All existing tests pass (88 tests)
- [x] New tests for each builder method
- [x] Immutability tests verify original client unchanged
- [x] Headers applied correctly on retries
- [x] Request-specific headers not overwritten

Closes #10