### PR TITLE
feat: add configuration infrastructure for authentication

### DIFF
--- a/cmd/utils/auth.go
+++ b/cmd/utils/auth.go
@@ -1,0 +1,300 @@
+package utils
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"regexp"
+	"time"
+
+	"github.com/spf13/viper"
+)
+
+// AuthMethod represents the type of authentication configured.
+type AuthMethod int
+
+const (
+	AuthMethodNone AuthMethod = iota
+	AuthMethodBasic
+	AuthMethodOAuth2
+	AuthMethodCertificate
+)
+
+// String returns the string representation of the auth method.
+func (m AuthMethod) String() string {
+	switch m {
+	case AuthMethodBasic:
+		return "basic"
+	case AuthMethodOAuth2:
+		return "oauth2"
+	case AuthMethodCertificate:
+		return "certificate"
+	default:
+		return "none"
+	}
+}
+
+// envVarPattern matches ${VAR} or $VAR syntax for environment variables.
+var envVarPattern = regexp.MustCompile(`\$\{([^}]+)\}|\$([A-Za-z_][A-Za-z0-9_]*)`)
+
+// expandEnvVars expands environment variables in the given string.
+// Supports both ${VAR} and $VAR syntax.
+// Returns the original string with all variables expanded.
+func expandEnvVars(s string) string {
+	return envVarPattern.ReplaceAllStringFunc(s, func(match string) string {
+		varName := extractVarName(match)
+		return os.Getenv(varName)
+	})
+}
+
+// extractVarName extracts the variable name from a match.
+// For "${VAR}" format, returns the content between braces.
+// For "$VAR" format, returns everything after the dollar sign.
+func extractVarName(match string) string {
+	if len(match) > 2 && match[1] == '{' {
+		return match[2 : len(match)-1]
+	}
+	return match[1:]
+}
+
+// ValidateAuthConfig validates the authentication configuration.
+// It ensures only one auth method is configured and all required fields are present.
+//
+// Note: This function mutates the config by expanding environment variables
+// in secret fields (password, client_secret). The expanded values replace
+// the original ${VAR} placeholders in the config struct.
+func ValidateAuthConfig(auth *AuthConfig) error {
+	if auth == nil {
+		return nil
+	}
+
+	count := countConfiguredAuthMethods(auth)
+	if count == 0 {
+		return fmt.Errorf("auth section present but no authentication method configured")
+	}
+	if count > 1 {
+		return fmt.Errorf("only one authentication method can be configured at a time")
+	}
+
+	if auth.Basic != nil {
+		return validateBasicAuth(auth.Basic)
+	}
+	if auth.OAuth2 != nil {
+		return validateOAuth2Auth(auth.OAuth2)
+	}
+	return validateCertificateAuth(auth.Certificate)
+}
+
+func countConfiguredAuthMethods(auth *AuthConfig) int {
+	count := 0
+	if auth.Basic != nil {
+		count++
+	}
+	if auth.OAuth2 != nil {
+		count++
+	}
+	if auth.Certificate != nil {
+		count++
+	}
+	return count
+}
+
+func validateBasicAuth(basic *BasicAuthConfig) error {
+	if basic.Username == "" {
+		return fmt.Errorf("auth.basic.user is required")
+	}
+	if basic.Password == "" {
+		return fmt.Errorf("auth.basic.password is required")
+	}
+	basic.Password = expandEnvVars(basic.Password)
+	return nil
+}
+
+func validateOAuth2Auth(oauth2 *OAuth2Config) error {
+	if oauth2.TokenURL == "" {
+		return fmt.Errorf("auth.oauth2.token_url is required")
+	}
+	if oauth2.ClientID == "" {
+		return fmt.Errorf("auth.oauth2.client_id is required")
+	}
+	if oauth2.ClientSecret == "" {
+		return fmt.Errorf("auth.oauth2.client_secret is required")
+	}
+	if _, err := url.Parse(oauth2.TokenURL); err != nil {
+		return fmt.Errorf("auth.oauth2.token_url is not a valid URL: %w", err)
+	}
+	oauth2.ClientSecret = expandEnvVars(oauth2.ClientSecret)
+	return nil
+}
+
+func validateCertificateAuth(cert *CertificateAuthConfig) error {
+	if cert.CertFile == "" {
+		return fmt.Errorf("auth.certificate.cert_file is required")
+	}
+	if cert.KeyFile == "" {
+		return fmt.Errorf("auth.certificate.key_file is required")
+	}
+	if err := validateFileExists(cert.CertFile, "certificate file"); err != nil {
+		return err
+	}
+	if err := validateFileExists(cert.KeyFile, "certificate key file"); err != nil {
+		return err
+	}
+	if cert.CAFile != "" {
+		if err := validateFileExists(cert.CAFile, "CA certificate file"); err != nil {
+			return err
+		}
+	}
+	if _, err := tls.LoadX509KeyPair(cert.CertFile, cert.KeyFile); err != nil {
+		return fmt.Errorf("failed to load certificate: %w", err)
+	}
+	return nil
+}
+
+func validateFileExists(path, description string) error {
+	if _, err := os.Stat(path); err != nil {
+		return fmt.Errorf("%s not found: %s: %w", description, path, err)
+	}
+	return nil
+}
+
+// GetAuthMethod returns which authentication method is configured.
+func GetAuthMethod(auth *AuthConfig) AuthMethod {
+	if auth == nil {
+		return AuthMethodNone
+	}
+	switch {
+	case auth.Basic != nil:
+		return AuthMethodBasic
+	case auth.OAuth2 != nil:
+		return AuthMethodOAuth2
+	case auth.Certificate != nil:
+		return AuthMethodCertificate
+	default:
+		return AuthMethodNone
+	}
+}
+
+// GetAuthenticatedClient returns an HTTP client with authentication applied.
+// If no auth is configured, returns a basic client.
+func GetAuthenticatedClient() (*Client, error) {
+	client := NewClient()
+
+	if !viper.IsSet("auth") {
+		return client, nil
+	}
+
+	var auth AuthConfig
+	if err := viper.UnmarshalKey("auth", &auth); err != nil {
+		return nil, fmt.Errorf("failed to parse auth configuration: %w", err)
+	}
+
+	method := GetAuthMethod(&auth)
+	if method == AuthMethodNone {
+		return client, nil
+	}
+
+	if err := ValidateAuthConfig(&auth); err != nil {
+		return nil, fmt.Errorf("invalid auth configuration: %w", err)
+	}
+
+	return applyAuthentication(client, method, &auth)
+}
+
+func applyAuthentication(client *Client, method AuthMethod, auth *AuthConfig) (*Client, error) {
+	switch method {
+	case AuthMethodBasic:
+		return client.WithBasicAuth(auth.Basic.Username, auth.Basic.Password), nil
+	case AuthMethodOAuth2:
+		token, err := fetchOAuth2Token(auth.OAuth2)
+		if err != nil {
+			return nil, fmt.Errorf("failed to fetch OAuth2 token: %w", err)
+		}
+		return client.WithBearerToken(token), nil
+	case AuthMethodCertificate:
+		return createCertificateClient(auth.Certificate)
+	}
+	return client, nil
+}
+
+// fetchOAuth2Token obtains an OAuth2 access token using client credentials flow.
+func fetchOAuth2Token(oauth2 *OAuth2Config) (string, error) {
+	data := url.Values{}
+	data.Set("grant_type", "client_credentials")
+	data.Set("client_id", oauth2.ClientID)
+	data.Set("client_secret", oauth2.ClientSecret)
+
+	// Use client with timeout to prevent hanging
+	httpClient := &http.Client{Timeout: 30 * time.Second}
+	resp, err := httpClient.PostForm(oauth2.TokenURL, data)
+	if err != nil {
+		return "", fmt.Errorf("token request failed: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return "", fmt.Errorf("token request failed with status %d: %s", resp.StatusCode, string(body))
+	}
+
+	var tokenResp struct {
+		AccessToken string `json:"access_token"`
+		TokenType   string `json:"token_type"`
+		ExpiresIn   int    `json:"expires_in"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&tokenResp); err != nil {
+		return "", fmt.Errorf("failed to decode token response: %w", err)
+	}
+
+	if tokenResp.AccessToken == "" {
+		return "", fmt.Errorf("access_token not found in response")
+	}
+
+	return tokenResp.AccessToken, nil
+}
+
+// createCertificateClient creates a client configured for mutual TLS.
+func createCertificateClient(cert *CertificateAuthConfig) (*Client, error) {
+	tlsCert, err := tls.LoadX509KeyPair(cert.CertFile, cert.KeyFile)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load certificate: %w", err)
+	}
+
+	tlsConfig := &tls.Config{
+		Certificates: []tls.Certificate{tlsCert},
+	}
+
+	if cert.CAFile != "" {
+		caCertPool, err := loadCACertPool(cert.CAFile)
+		if err != nil {
+			return nil, err
+		}
+		tlsConfig.RootCAs = caCertPool
+	}
+
+	httpClient := &http.Client{
+		Timeout: 30 * time.Second,
+		Transport: &http.Transport{
+			TLSClientConfig: tlsConfig,
+		},
+	}
+
+	return NewClientWithHTTPClient(httpClient), nil
+}
+
+func loadCACertPool(caFile string) (*x509.CertPool, error) {
+	caCert, err := os.ReadFile(caFile)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read CA certificate: %w", err)
+	}
+	caCertPool := x509.NewCertPool()
+	if !caCertPool.AppendCertsFromPEM(caCert) {
+		return nil, fmt.Errorf("failed to parse CA certificate from %s", caFile)
+	}
+	return caCertPool, nil
+}

--- a/cmd/utils/auth_test.go
+++ b/cmd/utils/auth_test.go
@@ -1,0 +1,538 @@
+package utils
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/spf13/viper"
+)
+
+func TestExpandEnvVars(t *testing.T) {
+	// Set up test environment variables using t.Setenv (automatically cleaned up)
+	t.Setenv("TEST_VAR", "secret_value")
+	t.Setenv("ANOTHER_VAR", "another_secret")
+
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "no variables",
+			input:    "plain text",
+			expected: "plain text",
+		},
+		{
+			name:     "single ${VAR} syntax",
+			input:    "${TEST_VAR}",
+			expected: "secret_value",
+		},
+		{
+			name:     "single $VAR syntax",
+			input:    "$TEST_VAR",
+			expected: "secret_value",
+		},
+		{
+			name:     "variable with surrounding text",
+			input:    "prefix_${TEST_VAR}_suffix",
+			expected: "prefix_secret_value_suffix",
+		},
+		{
+			name:     "multiple variables",
+			input:    "${TEST_VAR}:${ANOTHER_VAR}",
+			expected: "secret_value:another_secret",
+		},
+		{
+			name:     "undefined variable expands to empty",
+			input:    "${UNDEFINED_VAR}",
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := expandEnvVars(tt.input)
+			if result != tt.expected {
+				t.Errorf("expandEnvVars(%q) = %q, want %q", tt.input, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestValidateAuthConfig_NilConfig(t *testing.T) {
+	err := ValidateAuthConfig(nil)
+	if err != nil {
+		t.Errorf("ValidateAuthConfig(nil) = %v, want nil", err)
+	}
+}
+
+func TestValidateAuthConfig_EmptyConfig(t *testing.T) {
+	auth := &AuthConfig{}
+	err := ValidateAuthConfig(auth)
+	if err == nil {
+		t.Error("ValidateAuthConfig(empty) should return error")
+	}
+}
+
+func TestValidateAuthConfig_MultipleMethodsError(t *testing.T) {
+	auth := &AuthConfig{
+		Basic: &BasicAuthConfig{
+			Username: "user",
+			Password: "pass",
+		},
+		OAuth2: &OAuth2Config{
+			TokenURL:     "https://auth.example.com/token",
+			ClientID:     "client",
+			ClientSecret: "secret",
+		},
+	}
+
+	err := ValidateAuthConfig(auth)
+	if err == nil {
+		t.Error("ValidateAuthConfig with multiple methods should return error")
+	}
+	if err != nil && err.Error() != "only one authentication method can be configured at a time" {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestValidateAuthConfig_BasicAuth(t *testing.T) {
+	tests := []struct {
+		name      string
+		config    *AuthConfig
+		wantErr   bool
+		errSubstr string
+	}{
+		{
+			name: "valid basic auth",
+			config: &AuthConfig{
+				Basic: &BasicAuthConfig{
+					Username: "user",
+					Password: "pass",
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "missing username",
+			config: &AuthConfig{
+				Basic: &BasicAuthConfig{
+					Password: "pass",
+				},
+			},
+			wantErr:   true,
+			errSubstr: "user is required",
+		},
+		{
+			name: "missing password",
+			config: &AuthConfig{
+				Basic: &BasicAuthConfig{
+					Username: "user",
+				},
+			},
+			wantErr:   true,
+			errSubstr: "password is required",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateAuthConfig(tt.config)
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("expected error containing %q, got nil", tt.errSubstr)
+				} else if !strings.Contains(err.Error(), tt.errSubstr) {
+					t.Errorf("expected error containing %q, got %q", tt.errSubstr, err.Error())
+				}
+			} else if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+func TestValidateAuthConfig_BasicAuth_EnvVarExpansion(t *testing.T) {
+	t.Setenv("TEST_PASSWORD", "expanded_secret")
+
+	auth := &AuthConfig{
+		Basic: &BasicAuthConfig{
+			Username: "user",
+			Password: "${TEST_PASSWORD}",
+		},
+	}
+
+	err := ValidateAuthConfig(auth)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if auth.Basic.Password != "expanded_secret" {
+		t.Errorf("password not expanded: got %q, want %q", auth.Basic.Password, "expanded_secret")
+	}
+}
+
+func TestValidateAuthConfig_OAuth2(t *testing.T) {
+	tests := []struct {
+		name      string
+		config    *AuthConfig
+		wantErr   bool
+		errSubstr string
+	}{
+		{
+			name: "valid oauth2",
+			config: &AuthConfig{
+				OAuth2: &OAuth2Config{
+					TokenURL:     "https://auth.example.com/token",
+					ClientID:     "client",
+					ClientSecret: "secret",
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "missing token_url",
+			config: &AuthConfig{
+				OAuth2: &OAuth2Config{
+					ClientID:     "client",
+					ClientSecret: "secret",
+				},
+			},
+			wantErr:   true,
+			errSubstr: "token_url is required",
+		},
+		{
+			name: "missing client_id",
+			config: &AuthConfig{
+				OAuth2: &OAuth2Config{
+					TokenURL:     "https://auth.example.com/token",
+					ClientSecret: "secret",
+				},
+			},
+			wantErr:   true,
+			errSubstr: "client_id is required",
+		},
+		{
+			name: "missing client_secret",
+			config: &AuthConfig{
+				OAuth2: &OAuth2Config{
+					TokenURL: "https://auth.example.com/token",
+					ClientID: "client",
+				},
+			},
+			wantErr:   true,
+			errSubstr: "client_secret is required",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateAuthConfig(tt.config)
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("expected error containing %q, got nil", tt.errSubstr)
+				} else if !strings.Contains(err.Error(), tt.errSubstr) {
+					t.Errorf("expected error containing %q, got %q", tt.errSubstr, err.Error())
+				}
+			} else if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+func TestValidateAuthConfig_Certificate(t *testing.T) {
+	// Create temporary certificate files for testing
+	tempDir := t.TempDir()
+	certFile := filepath.Join(tempDir, "client.crt")
+	keyFile := filepath.Join(tempDir, "client.key")
+
+	// Generate test certificate
+	if err := generateTestCertificate(certFile, keyFile); err != nil {
+		t.Fatalf("failed to generate test certificate: %v", err)
+	}
+
+	tests := []struct {
+		name      string
+		config    *AuthConfig
+		wantErr   bool
+		errSubstr string
+	}{
+		{
+			name: "valid certificate",
+			config: &AuthConfig{
+				Certificate: &CertificateAuthConfig{
+					CertFile: certFile,
+					KeyFile:  keyFile,
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "missing cert_file",
+			config: &AuthConfig{
+				Certificate: &CertificateAuthConfig{
+					KeyFile: keyFile,
+				},
+			},
+			wantErr:   true,
+			errSubstr: "cert_file is required",
+		},
+		{
+			name: "missing key_file",
+			config: &AuthConfig{
+				Certificate: &CertificateAuthConfig{
+					CertFile: certFile,
+				},
+			},
+			wantErr:   true,
+			errSubstr: "key_file is required",
+		},
+		{
+			name: "cert file not found",
+			config: &AuthConfig{
+				Certificate: &CertificateAuthConfig{
+					CertFile: "/nonexistent/cert.crt",
+					KeyFile:  keyFile,
+				},
+			},
+			wantErr:   true,
+			errSubstr: "certificate file not found",
+		},
+		{
+			name: "key file not found",
+			config: &AuthConfig{
+				Certificate: &CertificateAuthConfig{
+					CertFile: certFile,
+					KeyFile:  "/nonexistent/key.key",
+				},
+			},
+			wantErr:   true,
+			errSubstr: "key file not found",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateAuthConfig(tt.config)
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("expected error containing %q, got nil", tt.errSubstr)
+				} else if !strings.Contains(err.Error(), tt.errSubstr) {
+					t.Errorf("expected error containing %q, got %q", tt.errSubstr, err.Error())
+				}
+			} else if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+func TestGetAuthMethod(t *testing.T) {
+	tests := []struct {
+		name     string
+		config   *AuthConfig
+		expected AuthMethod
+	}{
+		{
+			name:     "nil config",
+			config:   nil,
+			expected: AuthMethodNone,
+		},
+		{
+			name:     "empty config",
+			config:   &AuthConfig{},
+			expected: AuthMethodNone,
+		},
+		{
+			name: "basic auth",
+			config: &AuthConfig{
+				Basic: &BasicAuthConfig{Username: "user", Password: "pass"},
+			},
+			expected: AuthMethodBasic,
+		},
+		{
+			name: "oauth2",
+			config: &AuthConfig{
+				OAuth2: &OAuth2Config{TokenURL: "url", ClientID: "id", ClientSecret: "secret"},
+			},
+			expected: AuthMethodOAuth2,
+		},
+		{
+			name: "certificate",
+			config: &AuthConfig{
+				Certificate: &CertificateAuthConfig{CertFile: "cert", KeyFile: "key"},
+			},
+			expected: AuthMethodCertificate,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := GetAuthMethod(tt.config)
+			if result != tt.expected {
+				t.Errorf("GetAuthMethod() = %v, want %v", result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestAuthMethodString(t *testing.T) {
+	tests := []struct {
+		method   AuthMethod
+		expected string
+	}{
+		{AuthMethodNone, "none"},
+		{AuthMethodBasic, "basic"},
+		{AuthMethodOAuth2, "oauth2"},
+		{AuthMethodCertificate, "certificate"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.expected, func(t *testing.T) {
+			if tt.method.String() != tt.expected {
+				t.Errorf("AuthMethod.String() = %q, want %q", tt.method.String(), tt.expected)
+			}
+		})
+	}
+}
+
+func TestFetchOAuth2Token(t *testing.T) {
+	// Set up mock OAuth2 server
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "POST" {
+			t.Errorf("expected POST, got %s", r.Method)
+		}
+
+		if err := r.ParseForm(); err != nil {
+			t.Errorf("failed to parse form: %v", err)
+		}
+
+		if r.FormValue("grant_type") != "client_credentials" {
+			t.Errorf("expected grant_type=client_credentials, got %s", r.FormValue("grant_type"))
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"access_token": "test_token", "token_type": "Bearer", "expires_in": 3600}`))
+	}))
+	defer server.Close()
+
+	config := &OAuth2Config{
+		TokenURL:     server.URL,
+		ClientID:     "test_client",
+		ClientSecret: "test_secret",
+	}
+
+	token, err := fetchOAuth2Token(config)
+	if err != nil {
+		t.Fatalf("fetchOAuth2Token() error = %v", err)
+	}
+
+	if token != "test_token" {
+		t.Errorf("fetchOAuth2Token() = %q, want %q", token, "test_token")
+	}
+}
+
+func TestFetchOAuth2Token_Error(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"error": "invalid_client"}`))
+	}))
+	defer server.Close()
+
+	config := &OAuth2Config{
+		TokenURL:     server.URL,
+		ClientID:     "wrong_client",
+		ClientSecret: "wrong_secret",
+	}
+
+	_, err := fetchOAuth2Token(config)
+	if err == nil {
+		t.Error("fetchOAuth2Token() expected error for 401 response")
+	}
+}
+
+func TestGetAuthenticatedClient_NoAuth(t *testing.T) {
+	// Reset viper
+	viper.Reset()
+	viper.Set("api.base_url", "http://localhost:8080")
+
+	client, err := GetAuthenticatedClient()
+	if err != nil {
+		t.Fatalf("GetAuthenticatedClient() error = %v", err)
+	}
+	if client == nil {
+		t.Error("GetAuthenticatedClient() returned nil client")
+	}
+}
+
+func TestGetAuthenticatedClient_BasicAuth(t *testing.T) {
+	viper.Reset()
+	viper.Set("api.base_url", "http://localhost:8080")
+	viper.Set("auth.basic.user", "testuser")
+	viper.Set("auth.basic.password", "testpass")
+
+	client, err := GetAuthenticatedClient()
+	if err != nil {
+		t.Fatalf("GetAuthenticatedClient() error = %v", err)
+	}
+	if client == nil {
+		t.Error("GetAuthenticatedClient() returned nil client")
+	}
+}
+
+// generateTestCertificate generates a self-signed certificate for testing
+func generateTestCertificate(certFile, keyFile string) error {
+	priv, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		return err
+	}
+
+	template := x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject: pkix.Name{
+			Organization: []string{"Test"},
+		},
+		NotBefore:             time.Now(),
+		NotAfter:              time.Now().Add(time.Hour),
+		KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+		BasicConstraintsValid: true,
+	}
+
+	derBytes, err := x509.CreateCertificate(rand.Reader, &template, &template, &priv.PublicKey, priv)
+	if err != nil {
+		return err
+	}
+
+	certOut, err := os.Create(certFile)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = certOut.Close() }()
+	if err := pem.Encode(certOut, &pem.Block{Type: "CERTIFICATE", Bytes: derBytes}); err != nil {
+		return err
+	}
+
+	keyOut, err := os.Create(keyFile)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = keyOut.Close() }()
+	if err := pem.Encode(keyOut, &pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(priv)}); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/cmd/utils/configPath.go
+++ b/cmd/utils/configPath.go
@@ -16,12 +16,41 @@ const (
 
 // ConfigFile represents the structure of config.yaml
 type ConfigFile struct {
-	Api ApiConfig `yaml:"api"`
+	Api  ApiConfig   `yaml:"api"`
+	Auth *AuthConfig `yaml:"auth,omitempty"`
 }
 
 // ApiConfig represents the api section of config
 type ApiConfig struct {
 	BaseUrl string `yaml:"base_url"`
+}
+
+// AuthConfig represents authentication configuration.
+// Only one authentication method should be configured at a time.
+type AuthConfig struct {
+	Basic       *BasicAuthConfig       `yaml:"basic,omitempty"`
+	OAuth2      *OAuth2Config          `yaml:"oauth2,omitempty"`
+	Certificate *CertificateAuthConfig `yaml:"certificate,omitempty"`
+}
+
+// BasicAuthConfig represents HTTP Basic authentication credentials.
+type BasicAuthConfig struct {
+	Username string `yaml:"user" mapstructure:"user"`
+	Password string `yaml:"password" mapstructure:"password"` // Supports ${VAR} syntax for env vars
+}
+
+// OAuth2Config represents OAuth2 client credentials configuration.
+type OAuth2Config struct {
+	TokenURL     string `yaml:"token_url" mapstructure:"token_url"`
+	ClientID     string `yaml:"client_id" mapstructure:"client_id"`
+	ClientSecret string `yaml:"client_secret" mapstructure:"client_secret"` // Supports ${VAR} syntax for env vars
+}
+
+// CertificateAuthConfig represents mutual TLS authentication configuration.
+type CertificateAuthConfig struct {
+	CertFile string `yaml:"cert_file" mapstructure:"cert_file"`
+	KeyFile  string `yaml:"key_file" mapstructure:"key_file"`
+	CAFile   string `yaml:"ca_file,omitempty" mapstructure:"ca_file"` // Optional CA certificate
 }
 
 // GetConfigDir returns the OS-specific config directory for ftsctl

--- a/cmd/utils/httpclient.go
+++ b/cmd/utils/httpclient.go
@@ -3,6 +3,7 @@ package utils
 import (
 	"bytes"
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -138,6 +139,15 @@ func (c *Client) WithAPIKey(key string) *Client {
 	return c.WithHeader("X-API-Key", key)
 }
 
+// WithBasicAuth returns a new Client with HTTP Basic authentication.
+// Sets the Authorization header to "Basic {base64(username:password)}".
+// Returns a new Client; does not modify the receiver.
+func (c *Client) WithBasicAuth(username, password string) *Client {
+	auth := username + ":" + password
+	encoded := base64.StdEncoding.EncodeToString([]byte(auth))
+	return c.WithHeader("Authorization", "Basic "+encoded)
+}
+
 // WithBaseBackoff returns a new Client with the specified base backoff duration.
 // This is primarily useful in tests to speed up retry scenarios.
 // Returns a new Client; does not modify the receiver.
@@ -151,15 +161,16 @@ func (c *Client) WithBaseBackoff(d time.Duration) *Client {
 // Does not overwrite headers already set on the request.
 // This preserves request-specific headers like Content-Type.
 func (c *Client) applyHeaders(req *http.Request) {
-	if c.headers == nil || req == nil {
+	if req == nil || c.headers == nil {
 		return
 	}
 
 	for key, values := range c.headers {
-		if req.Header.Get(key) == "" {
-			for _, value := range values {
-				req.Header.Add(key, value)
-			}
+		if req.Header.Get(key) != "" {
+			continue
+		}
+		for _, value := range values {
+			req.Header.Add(key, value)
 		}
 	}
 }

--- a/cmd/utils/httpclient_test.go
+++ b/cmd/utils/httpclient_test.go
@@ -614,6 +614,33 @@ func TestClient_WithAPIKey(t *testing.T) {
 	}
 }
 
+func TestClient_WithBasicAuth(t *testing.T) {
+	var capturedHeaders http.Header
+	mockClient := &MockHTTPClient{
+		DoFunc: func(req *http.Request) (*http.Response, error) {
+			capturedHeaders = req.Header
+			return newMockResponse(200, `{"success": true}`), nil
+		},
+	}
+
+	client := NewClientWithHTTPClient(mockClient).
+		WithBasicAuth("testuser", "testpass")
+
+	var result map[string]bool
+	err := client.GetJSON(context.Background(), "/api/v2/test", &result)
+	if err != nil {
+		t.Fatalf("Expected no error, got: %v", err)
+	}
+
+	authHeader := capturedHeaders.Get("Authorization")
+	// Basic auth should be "Basic base64(user:pass)"
+	// "testuser:testpass" in base64 is "dGVzdHVzZXI6dGVzdHBhc3M="
+	expected := "Basic dGVzdHVzZXI6dGVzdHBhc3M="
+	if authHeader != expected {
+		t.Errorf("Expected Authorization to be '%s', got: %s", expected, authHeader)
+	}
+}
+
 func TestClient_ImmutableHeaders(t *testing.T) {
 	baseClient := NewClientWithHTTPClient(&MockHTTPClient{
 		DoFunc: func(req *http.Request) (*http.Response, error) {


### PR DESCRIPTION
## Summary

Add support for three authentication methods in the configuration:
- Basic authentication (username/password)
- OAuth2 client credentials flow
- Certificate-based mutual TLS

Key features:
- Environment variable expansion (`${VAR}` syntax) for secrets
- Eager validation at config load time
- Mutual exclusivity (only one auth method allowed)
- File existence validation for certificates
- `GetAuthenticatedClient()` factory for creating authenticated clients

## Test plan

- [x] All existing tests pass
- [x] New tests for auth validation cover all auth types
- [x] OAuth2 token fetching tested with httptest server
- [x] Certificate validation tested with generated test certificates
- [x] Environment variable expansion tested

Closes #22