### PR TITLE
feat: add OAuth2 client credentials support

### DIFF
--- a/cmd/utils/auth.go
+++ b/cmd/utils/auth.go
@@ -3,9 +3,7 @@ package utils
 import (
 	"crypto/tls"
 	"crypto/x509"
-	"encoding/json"
 	"fmt"
-	"io"
 	"net/http"
 	"net/url"
 	"os"
@@ -211,7 +209,8 @@ func applyAuthentication(client *Client, method AuthMethod, auth *AuthConfig) (*
 	case AuthMethodBasic:
 		return client.WithBasicAuth(auth.Basic.Username, auth.Basic.Password), nil
 	case AuthMethodOAuth2:
-		token, err := fetchOAuth2Token(auth.OAuth2)
+		tokenProvider := NewOAuth2TokenProvider(auth.OAuth2)
+		token, err := tokenProvider.GetToken()
 		if err != nil {
 			return nil, fmt.Errorf("failed to fetch OAuth2 token: %w", err)
 		}
@@ -220,42 +219,6 @@ func applyAuthentication(client *Client, method AuthMethod, auth *AuthConfig) (*
 		return createCertificateClient(auth.Certificate)
 	}
 	return client, nil
-}
-
-// fetchOAuth2Token obtains an OAuth2 access token using client credentials flow.
-func fetchOAuth2Token(oauth2 *OAuth2Config) (string, error) {
-	data := url.Values{}
-	data.Set("grant_type", "client_credentials")
-	data.Set("client_id", oauth2.ClientID)
-	data.Set("client_secret", oauth2.ClientSecret)
-
-	// Use client with timeout to prevent hanging
-	httpClient := &http.Client{Timeout: 30 * time.Second}
-	resp, err := httpClient.PostForm(oauth2.TokenURL, data)
-	if err != nil {
-		return "", fmt.Errorf("token request failed: %w", err)
-	}
-	defer func() { _ = resp.Body.Close() }()
-
-	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(resp.Body)
-		return "", fmt.Errorf("token request failed with status %d: %s", resp.StatusCode, string(body))
-	}
-
-	var tokenResp struct {
-		AccessToken string `json:"access_token"`
-		TokenType   string `json:"token_type"`
-		ExpiresIn   int    `json:"expires_in"`
-	}
-	if err := json.NewDecoder(resp.Body).Decode(&tokenResp); err != nil {
-		return "", fmt.Errorf("failed to decode token response: %w", err)
-	}
-
-	if tokenResp.AccessToken == "" {
-		return "", fmt.Errorf("access_token not found in response")
-	}
-
-	return tokenResp.AccessToken, nil
 }
 
 // createCertificateClient creates a client configured for mutual TLS.

--- a/cmd/utils/auth_test.go
+++ b/cmd/utils/auth_test.go
@@ -423,62 +423,6 @@ func TestAuthMethodString(t *testing.T) {
 	}
 }
 
-func TestFetchOAuth2Token(t *testing.T) {
-	// Set up mock OAuth2 server
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != "POST" {
-			t.Errorf("expected POST, got %s", r.Method)
-		}
-
-		if err := r.ParseForm(); err != nil {
-			t.Errorf("failed to parse form: %v", err)
-		}
-
-		if r.FormValue("grant_type") != "client_credentials" {
-			t.Errorf("expected grant_type=client_credentials, got %s", r.FormValue("grant_type"))
-		}
-
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusOK)
-		_, _ = w.Write([]byte(`{"access_token": "test_token", "token_type": "Bearer", "expires_in": 3600}`))
-	}))
-	defer server.Close()
-
-	config := &OAuth2Config{
-		TokenURL:     server.URL,
-		ClientID:     "test_client",
-		ClientSecret: "test_secret",
-	}
-
-	token, err := fetchOAuth2Token(config)
-	if err != nil {
-		t.Fatalf("fetchOAuth2Token() error = %v", err)
-	}
-
-	if token != "test_token" {
-		t.Errorf("fetchOAuth2Token() = %q, want %q", token, "test_token")
-	}
-}
-
-func TestFetchOAuth2Token_Error(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusUnauthorized)
-		_, _ = w.Write([]byte(`{"error": "invalid_client"}`))
-	}))
-	defer server.Close()
-
-	config := &OAuth2Config{
-		TokenURL:     server.URL,
-		ClientID:     "wrong_client",
-		ClientSecret: "wrong_secret",
-	}
-
-	_, err := fetchOAuth2Token(config)
-	if err == nil {
-		t.Error("fetchOAuth2Token() expected error for 401 response")
-	}
-}
-
 func TestGetAuthenticatedClient_NoAuth(t *testing.T) {
 	// Reset viper
 	viper.Reset()

--- a/cmd/utils/configPath.go
+++ b/cmd/utils/configPath.go
@@ -44,6 +44,7 @@ type OAuth2Config struct {
 	TokenURL     string `yaml:"token_url" mapstructure:"token_url"`
 	ClientID     string `yaml:"client_id" mapstructure:"client_id"`
 	ClientSecret string `yaml:"client_secret" mapstructure:"client_secret"` // Supports ${VAR} syntax for env vars
+	Scope        string `yaml:"scope,omitempty" mapstructure:"scope"`       // Optional scope parameter
 }
 
 // CertificateAuthConfig represents mutual TLS authentication configuration.

--- a/cmd/utils/oauth2.go
+++ b/cmd/utils/oauth2.go
@@ -1,0 +1,103 @@
+package utils
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"time"
+)
+
+// OAuth2Token represents a cached OAuth2 access token with expiry information.
+type OAuth2Token struct {
+	AccessToken string
+	ExpiresAt   time.Time
+}
+
+// IsExpired returns true if the token is expired or will expire within the buffer period.
+// Uses a 30-second buffer to avoid using tokens that are about to expire.
+func (t *OAuth2Token) IsExpired() bool {
+	if t == nil {
+		return true
+	}
+	return time.Now().Add(30 * time.Second).After(t.ExpiresAt)
+}
+
+// OAuth2TokenProvider manages OAuth2 token acquisition and caching.
+// It fetches tokens using the client credentials grant and caches them
+// until they expire.
+type OAuth2TokenProvider struct {
+	config     *OAuth2Config
+	token      *OAuth2Token
+	httpClient *http.Client
+}
+
+// NewOAuth2TokenProvider creates a new token provider for the given configuration.
+func NewOAuth2TokenProvider(config *OAuth2Config) *OAuth2TokenProvider {
+	return &OAuth2TokenProvider{
+		config:     config,
+		httpClient: &http.Client{Timeout: 30 * time.Second},
+	}
+}
+
+// GetToken returns a valid access token, fetching a new one if the cached token
+// is expired or doesn't exist.
+func (p *OAuth2TokenProvider) GetToken() (string, error) {
+	if p.token != nil && !p.token.IsExpired() {
+		return p.token.AccessToken, nil
+	}
+
+	token, err := p.fetchToken()
+	if err != nil {
+		return "", err
+	}
+
+	p.token = token
+	return token.AccessToken, nil
+}
+
+// fetchToken requests a new access token from the OAuth2 token endpoint.
+func (p *OAuth2TokenProvider) fetchToken() (*OAuth2Token, error) {
+	data := url.Values{}
+	data.Set("grant_type", "client_credentials")
+	data.Set("client_id", p.config.ClientID)
+	data.Set("client_secret", p.config.ClientSecret)
+	if p.config.Scope != "" {
+		data.Set("scope", p.config.Scope)
+	}
+
+	resp, err := p.httpClient.PostForm(p.config.TokenURL, data)
+	if err != nil {
+		return nil, fmt.Errorf("token request failed: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("token request failed with status %d: %s", resp.StatusCode, string(body))
+	}
+
+	var tokenResp struct {
+		AccessToken string `json:"access_token"`
+		ExpiresIn   int    `json:"expires_in"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&tokenResp); err != nil {
+		return nil, fmt.Errorf("failed to decode token response: %w", err)
+	}
+
+	if tokenResp.AccessToken == "" {
+		return nil, fmt.Errorf("access_token not found in response")
+	}
+
+	// Default to 5 minutes if expires_in is not provided
+	expiresIn := tokenResp.ExpiresIn
+	if expiresIn <= 0 {
+		expiresIn = 300
+	}
+
+	return &OAuth2Token{
+		AccessToken: tokenResp.AccessToken,
+		ExpiresAt:   time.Now().Add(time.Duration(expiresIn) * time.Second),
+	}, nil
+}

--- a/cmd/utils/oauth2_test.go
+++ b/cmd/utils/oauth2_test.go
@@ -1,0 +1,300 @@
+package utils
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestOAuth2Token_IsExpired(t *testing.T) {
+	tests := []struct {
+		name        string
+		token       *OAuth2Token
+		wantExpired bool
+	}{
+		{
+			name:        "nil token is expired",
+			token:       nil,
+			wantExpired: true,
+		},
+		{
+			name: "expired token",
+			token: &OAuth2Token{
+				AccessToken: "token",
+				ExpiresAt:   time.Now().Add(-1 * time.Minute),
+			},
+			wantExpired: true,
+		},
+		{
+			name: "token expiring within buffer (30s)",
+			token: &OAuth2Token{
+				AccessToken: "token",
+				ExpiresAt:   time.Now().Add(20 * time.Second),
+			},
+			wantExpired: true,
+		},
+		{
+			name: "valid token",
+			token: &OAuth2Token{
+				AccessToken: "token",
+				ExpiresAt:   time.Now().Add(5 * time.Minute),
+			},
+			wantExpired: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.token.IsExpired(); got != tt.wantExpired {
+				t.Errorf("IsExpired() = %v, want %v", got, tt.wantExpired)
+			}
+		})
+	}
+}
+
+func TestOAuth2TokenProvider_GetToken_Success(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "POST" {
+			t.Errorf("expected POST, got %s", r.Method)
+		}
+		if err := r.ParseForm(); err != nil {
+			t.Errorf("failed to parse form: %v", err)
+		}
+		if r.FormValue("grant_type") != "client_credentials" {
+			t.Errorf("expected grant_type=client_credentials, got %s", r.FormValue("grant_type"))
+		}
+		if r.FormValue("client_id") != "test_client" {
+			t.Errorf("expected client_id=test_client, got %s", r.FormValue("client_id"))
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"access_token": "test_token", "token_type": "Bearer", "expires_in": 3600}`))
+	}))
+	defer server.Close()
+
+	provider := NewOAuth2TokenProvider(&OAuth2Config{
+		TokenURL:     server.URL,
+		ClientID:     "test_client",
+		ClientSecret: "test_secret",
+	})
+
+	token, err := provider.GetToken()
+	if err != nil {
+		t.Fatalf("GetToken() error = %v", err)
+	}
+	if token != "test_token" {
+		t.Errorf("GetToken() = %q, want %q", token, "test_token")
+	}
+}
+
+func TestOAuth2TokenProvider_GetToken_WithScope(t *testing.T) {
+	var receivedScope string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := r.ParseForm(); err != nil {
+			t.Errorf("failed to parse form: %v", err)
+		}
+		receivedScope = r.FormValue("scope")
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"access_token": "scoped_token", "expires_in": 3600}`))
+	}))
+	defer server.Close()
+
+	provider := NewOAuth2TokenProvider(&OAuth2Config{
+		TokenURL:     server.URL,
+		ClientID:     "client",
+		ClientSecret: "secret",
+		Scope:        "read write",
+	})
+
+	_, err := provider.GetToken()
+	if err != nil {
+		t.Fatalf("GetToken() error = %v", err)
+	}
+	if receivedScope != "read write" {
+		t.Errorf("scope = %q, want %q", receivedScope, "read write")
+	}
+}
+
+func TestOAuth2TokenProvider_GetToken_NoScope(t *testing.T) {
+	var scopePresent bool
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := r.ParseForm(); err != nil {
+			t.Errorf("failed to parse form: %v", err)
+		}
+		_, scopePresent = r.Form["scope"]
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"access_token": "token", "expires_in": 3600}`))
+	}))
+	defer server.Close()
+
+	provider := NewOAuth2TokenProvider(&OAuth2Config{
+		TokenURL:     server.URL,
+		ClientID:     "client",
+		ClientSecret: "secret",
+		// No scope
+	})
+
+	_, err := provider.GetToken()
+	if err != nil {
+		t.Fatalf("GetToken() error = %v", err)
+	}
+	if scopePresent {
+		t.Error("scope should not be present when not configured")
+	}
+}
+
+func TestOAuth2TokenProvider_GetToken_Caching(t *testing.T) {
+	var requestCount int32
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&requestCount, 1)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"access_token": "cached_token", "expires_in": 3600}`))
+	}))
+	defer server.Close()
+
+	provider := NewOAuth2TokenProvider(&OAuth2Config{
+		TokenURL:     server.URL,
+		ClientID:     "client",
+		ClientSecret: "secret",
+	})
+
+	// First call should fetch token
+	token1, err := provider.GetToken()
+	if err != nil {
+		t.Fatalf("First GetToken() error = %v", err)
+	}
+
+	// Second call should return cached token
+	token2, err := provider.GetToken()
+	if err != nil {
+		t.Fatalf("Second GetToken() error = %v", err)
+	}
+
+	// Third call should also return cached token
+	token3, err := provider.GetToken()
+	if err != nil {
+		t.Fatalf("Third GetToken() error = %v", err)
+	}
+
+	if token1 != token2 || token2 != token3 {
+		t.Errorf("tokens should be the same: %q, %q, %q", token1, token2, token3)
+	}
+
+	if count := atomic.LoadInt32(&requestCount); count != 1 {
+		t.Errorf("expected 1 request (caching), got %d", count)
+	}
+}
+
+func TestOAuth2TokenProvider_GetToken_RefreshOnExpiry(t *testing.T) {
+	var requestCount int32
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		count := atomic.AddInt32(&requestCount, 1)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		// Return token that expires in 1 second
+		_, _ = w.Write([]byte(`{"access_token": "token_` + string(rune('0'+count)) + `", "expires_in": 1}`))
+	}))
+	defer server.Close()
+
+	provider := NewOAuth2TokenProvider(&OAuth2Config{
+		TokenURL:     server.URL,
+		ClientID:     "client",
+		ClientSecret: "secret",
+	})
+
+	// First call
+	_, err := provider.GetToken()
+	if err != nil {
+		t.Fatalf("First GetToken() error = %v", err)
+	}
+
+	// Wait for token to expire (expires_in=1s, plus 30s buffer means it's already expired)
+	// The 30s buffer in IsExpired() means a 1s token is immediately considered expired
+	// So second call should fetch a new token
+	_, err = provider.GetToken()
+	if err != nil {
+		t.Fatalf("Second GetToken() error = %v", err)
+	}
+
+	if count := atomic.LoadInt32(&requestCount); count != 2 {
+		t.Errorf("expected 2 requests (token refresh), got %d", count)
+	}
+}
+
+func TestOAuth2TokenProvider_GetToken_Error(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"error": "invalid_client"}`))
+	}))
+	defer server.Close()
+
+	provider := NewOAuth2TokenProvider(&OAuth2Config{
+		TokenURL:     server.URL,
+		ClientID:     "wrong_client",
+		ClientSecret: "wrong_secret",
+	})
+
+	_, err := provider.GetToken()
+	if err == nil {
+		t.Error("expected error for 401 response")
+	}
+}
+
+func TestOAuth2TokenProvider_GetToken_MissingAccessToken(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"token_type": "Bearer", "expires_in": 3600}`))
+	}))
+	defer server.Close()
+
+	provider := NewOAuth2TokenProvider(&OAuth2Config{
+		TokenURL:     server.URL,
+		ClientID:     "client",
+		ClientSecret: "secret",
+	})
+
+	_, err := provider.GetToken()
+	if err == nil {
+		t.Error("expected error for missing access_token")
+	}
+}
+
+func TestOAuth2TokenProvider_GetToken_DefaultExpiresIn(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		// No expires_in field
+		_, _ = w.Write([]byte(`{"access_token": "token"}`))
+	}))
+	defer server.Close()
+
+	provider := NewOAuth2TokenProvider(&OAuth2Config{
+		TokenURL:     server.URL,
+		ClientID:     "client",
+		ClientSecret: "secret",
+	})
+
+	token, err := provider.GetToken()
+	if err != nil {
+		t.Fatalf("GetToken() error = %v", err)
+	}
+	if token != "token" {
+		t.Errorf("GetToken() = %q, want %q", token, "token")
+	}
+
+	// Token should not be expired (default 5 min expiry)
+	if provider.token.IsExpired() {
+		t.Error("token should not be expired with default expiry")
+	}
+}


### PR DESCRIPTION
## Summary

- Implement OAuth2 client credentials flow with token caching
- Add `OAuth2TokenProvider` for managing token lifecycle
- Proactive token refresh with 30-second expiry buffer
- Add optional `scope` parameter to OAuth2 configuration

## Configuration

```yaml
auth:
  oauth2:
    token_url: "https://auth.example.com/token"
    client_id: "ftsctl-client"
    client_secret: "${CLIENT_SECRET}"
    scope: "read write"  # Optional
```

## Test plan

- [x] Unit tests for OAuth2Token expiry logic
- [x] Tests for token caching (single request when token valid)
- [x] Tests for token refresh on expiry
- [x] Tests for scope parameter handling
- [x] Tests for error scenarios (401, missing access_token)
- [x] All existing tests pass

Closes #24