### PR TITLE
feat: add certificate authentication (mTLS) support

### DIFF
--- a/cmd/utils/auth.go
+++ b/cmd/utils/auth.go
@@ -1,14 +1,10 @@
 package utils
 
 import (
-	"crypto/tls"
-	"crypto/x509"
 	"fmt"
-	"net/http"
 	"net/url"
 	"os"
 	"regexp"
-	"time"
 
 	"github.com/spf13/viper"
 )
@@ -130,30 +126,6 @@ func validateOAuth2Auth(oauth2 *OAuth2Config) error {
 	return nil
 }
 
-func validateCertificateAuth(cert *CertificateAuthConfig) error {
-	if cert.CertFile == "" {
-		return fmt.Errorf("auth.certificate.cert_file is required")
-	}
-	if cert.KeyFile == "" {
-		return fmt.Errorf("auth.certificate.key_file is required")
-	}
-	if err := validateFileExists(cert.CertFile, "certificate file"); err != nil {
-		return err
-	}
-	if err := validateFileExists(cert.KeyFile, "certificate key file"); err != nil {
-		return err
-	}
-	if cert.CAFile != "" {
-		if err := validateFileExists(cert.CAFile, "CA certificate file"); err != nil {
-			return err
-		}
-	}
-	if _, err := tls.LoadX509KeyPair(cert.CertFile, cert.KeyFile); err != nil {
-		return fmt.Errorf("failed to load certificate: %w", err)
-	}
-	return nil
-}
-
 func validateFileExists(path, description string) error {
 	if _, err := os.Stat(path); err != nil {
 		return fmt.Errorf("%s not found: %s: %w", description, path, err)
@@ -216,48 +188,12 @@ func applyAuthentication(client *Client, method AuthMethod, auth *AuthConfig) (*
 		}
 		return client.WithBearerToken(token), nil
 	case AuthMethodCertificate:
-		return createCertificateClient(auth.Certificate)
-	}
-	return client, nil
-}
-
-// createCertificateClient creates a client configured for mutual TLS.
-func createCertificateClient(cert *CertificateAuthConfig) (*Client, error) {
-	tlsCert, err := tls.LoadX509KeyPair(cert.CertFile, cert.KeyFile)
-	if err != nil {
-		return nil, fmt.Errorf("failed to load certificate: %w", err)
-	}
-
-	tlsConfig := &tls.Config{
-		Certificates: []tls.Certificate{tlsCert},
-	}
-
-	if cert.CAFile != "" {
-		caCertPool, err := loadCACertPool(cert.CAFile)
-		if err != nil {
+		// Validate HTTPS is required for certificate authentication
+		baseURL := viper.GetString("api.base_url")
+		if err := validateCertificateAuthRequiresHTTPS(baseURL); err != nil {
 			return nil, err
 		}
-		tlsConfig.RootCAs = caCertPool
+		return applyCertificateAuth(client, auth.Certificate)
 	}
-
-	httpClient := &http.Client{
-		Timeout: 30 * time.Second,
-		Transport: &http.Transport{
-			TLSClientConfig: tlsConfig,
-		},
-	}
-
-	return NewClientWithHTTPClient(httpClient), nil
-}
-
-func loadCACertPool(caFile string) (*x509.CertPool, error) {
-	caCert, err := os.ReadFile(caFile)
-	if err != nil {
-		return nil, fmt.Errorf("failed to read CA certificate: %w", err)
-	}
-	caCertPool := x509.NewCertPool()
-	if !caCertPool.AppendCertsFromPEM(caCert) {
-		return nil, fmt.Errorf("failed to parse CA certificate from %s", caFile)
-	}
-	return caCertPool, nil
+	return client, nil
 }

--- a/cmd/utils/certificate.go
+++ b/cmd/utils/certificate.go
@@ -1,0 +1,113 @@
+package utils
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"net/http"
+	"net/url"
+	"os"
+	"time"
+)
+
+// applyCertificateAuth applies certificate authentication to an existing client.
+// It loads the client certificate and key, and optionally a custom CA certificate
+// for server verification. Returns a new client with TLS configuration; does not
+// modify the original client.
+func applyCertificateAuth(client *Client, cert *CertificateAuthConfig) (*Client, error) {
+	tlsCert, err := tls.LoadX509KeyPair(cert.CertFile, cert.KeyFile)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load certificate: %w", err)
+	}
+
+	tlsConfig := &tls.Config{
+		Certificates: []tls.Certificate{tlsCert},
+	}
+
+	if cert.CAFile != "" {
+		caCertPool, err := loadCACertPool(cert.CAFile)
+		if err != nil {
+			return nil, err
+		}
+		tlsConfig.RootCAs = caCertPool
+	}
+
+	httpClient := &http.Client{
+		Timeout: 30 * time.Second,
+		Transport: &http.Transport{
+			TLSClientConfig: tlsConfig,
+		},
+	}
+
+	return client.WithHTTPClient(httpClient), nil
+}
+
+// createCertificateClient creates a new client configured for mutual TLS.
+// This is a convenience function that creates a new base client and applies
+// certificate authentication to it.
+// Deprecated: Use applyCertificateAuth with an existing client for better
+// compatibility with the client injection mechanism.
+func createCertificateClient(cert *CertificateAuthConfig) (*Client, error) {
+	return applyCertificateAuth(NewClient(), cert)
+}
+
+// loadCACertPool loads a CA certificate from a PEM file and returns a certificate pool.
+func loadCACertPool(caFile string) (*x509.CertPool, error) {
+	caCert, err := os.ReadFile(caFile)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read CA certificate: %w", err)
+	}
+	caCertPool := x509.NewCertPool()
+	if !caCertPool.AppendCertsFromPEM(caCert) {
+		return nil, fmt.Errorf("failed to parse CA certificate from %s", caFile)
+	}
+	return caCertPool, nil
+}
+
+// validateCertificateAuth validates the certificate authentication configuration.
+// It checks that required files exist and that the certificate/key pair is valid.
+// It also validates that the base URL uses HTTPS when certificate auth is configured.
+func validateCertificateAuth(cert *CertificateAuthConfig) error {
+	if cert.CertFile == "" {
+		return fmt.Errorf("auth.certificate.cert_file is required")
+	}
+	if cert.KeyFile == "" {
+		return fmt.Errorf("auth.certificate.key_file is required")
+	}
+	if err := validateFileExists(cert.CertFile, "certificate file"); err != nil {
+		return err
+	}
+	if err := validateFileExists(cert.KeyFile, "certificate key file"); err != nil {
+		return err
+	}
+	if cert.CAFile != "" {
+		if err := validateFileExists(cert.CAFile, "CA certificate file"); err != nil {
+			return err
+		}
+		// Validate CA certificate is valid PEM
+		if _, err := loadCACertPool(cert.CAFile); err != nil {
+			return err
+		}
+	}
+	// Validate the certificate and key pair can be loaded
+	if _, err := tls.LoadX509KeyPair(cert.CertFile, cert.KeyFile); err != nil {
+		return fmt.Errorf("failed to load certificate: %w", err)
+	}
+	return nil
+}
+
+// validateCertificateAuthRequiresHTTPS validates that the base URL uses HTTPS
+// when certificate authentication is configured.
+func validateCertificateAuthRequiresHTTPS(baseURL string) error {
+	if baseURL == "" {
+		return fmt.Errorf("api.base_url is required when using certificate authentication")
+	}
+	parsedURL, err := url.Parse(baseURL)
+	if err != nil {
+		return fmt.Errorf("invalid api.base_url: %w", err)
+	}
+	if parsedURL.Scheme != "https" {
+		return fmt.Errorf("certificate authentication requires HTTPS, but api.base_url uses %s", parsedURL.Scheme)
+	}
+	return nil
+}

--- a/cmd/utils/certificate_test.go
+++ b/cmd/utils/certificate_test.go
@@ -1,0 +1,597 @@
+package utils
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/spf13/viper"
+)
+
+// TestCertificateAuthConfig holds all certificate files for a test scenario.
+type TestCertificateAuthConfig struct {
+	CACertFile     string
+	CAKeyFile      string
+	ServerCertFile string
+	ServerKeyFile  string
+	ClientCertFile string
+	ClientKeyFile  string
+}
+
+// generateTestCA generates a CA certificate and key for testing.
+func generateTestCA(certFile, keyFile string) error {
+	priv, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		return err
+	}
+
+	template := x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject: pkix.Name{
+			Organization: []string{"Test CA"},
+			CommonName:   "Test CA",
+		},
+		NotBefore:             time.Now(),
+		NotAfter:              time.Now().Add(time.Hour),
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
+		IsCA:                  true,
+		BasicConstraintsValid: true,
+	}
+
+	derBytes, err := x509.CreateCertificate(rand.Reader, &template, &template, &priv.PublicKey, priv)
+	if err != nil {
+		return err
+	}
+
+	if err := writeCertAndKey(certFile, keyFile, derBytes, priv); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// generateTestCertSignedByCA generates a certificate signed by the given CA.
+func generateTestCertSignedByCA(certFile, keyFile, caCertFile, caKeyFile string, isServer bool) error {
+	// Load CA
+	caCertPEM, err := os.ReadFile(caCertFile)
+	if err != nil {
+		return err
+	}
+	caKeyPEM, err := os.ReadFile(caKeyFile)
+	if err != nil {
+		return err
+	}
+
+	caCertBlock, _ := pem.Decode(caCertPEM)
+	caCert, err := x509.ParseCertificate(caCertBlock.Bytes)
+	if err != nil {
+		return err
+	}
+
+	caKeyBlock, _ := pem.Decode(caKeyPEM)
+	caKey, err := x509.ParsePKCS1PrivateKey(caKeyBlock.Bytes)
+	if err != nil {
+		return err
+	}
+
+	// Generate new key
+	priv, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		return err
+	}
+
+	template := x509.Certificate{
+		SerialNumber: big.NewInt(2),
+		Subject: pkix.Name{
+			Organization: []string{"Test"},
+			CommonName:   "localhost",
+		},
+		NotBefore:             time.Now(),
+		NotAfter:              time.Now().Add(time.Hour),
+		KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
+		BasicConstraintsValid: true,
+		DNSNames:              []string{"localhost"},
+		IPAddresses:           []net.IP{net.IPv4(127, 0, 0, 1)},
+	}
+
+	if isServer {
+		template.ExtKeyUsage = []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth}
+	} else {
+		template.ExtKeyUsage = []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth}
+	}
+
+	derBytes, err := x509.CreateCertificate(rand.Reader, &template, caCert, &priv.PublicKey, caKey)
+	if err != nil {
+		return err
+	}
+
+	return writeCertAndKey(certFile, keyFile, derBytes, priv)
+}
+
+func writeCertAndKey(certFile, keyFile string, certDER []byte, key *rsa.PrivateKey) error {
+	certOut, err := os.Create(certFile)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = certOut.Close() }()
+	if err := pem.Encode(certOut, &pem.Block{Type: "CERTIFICATE", Bytes: certDER}); err != nil {
+		return err
+	}
+
+	keyOut, err := os.Create(keyFile)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = keyOut.Close() }()
+	if err := pem.Encode(keyOut, &pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(key)}); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// setupTestCertificates creates a full PKI for testing mTLS.
+func setupTestCertificates(t *testing.T) *TestCertificateAuthConfig {
+	t.Helper()
+	tempDir := t.TempDir()
+
+	cfg := &TestCertificateAuthConfig{
+		CACertFile:     filepath.Join(tempDir, "ca.crt"),
+		CAKeyFile:      filepath.Join(tempDir, "ca.key"),
+		ServerCertFile: filepath.Join(tempDir, "server.crt"),
+		ServerKeyFile:  filepath.Join(tempDir, "server.key"),
+		ClientCertFile: filepath.Join(tempDir, "client.crt"),
+		ClientKeyFile:  filepath.Join(tempDir, "client.key"),
+	}
+
+	// Generate CA
+	if err := generateTestCA(cfg.CACertFile, cfg.CAKeyFile); err != nil {
+		t.Fatalf("failed to generate CA: %v", err)
+	}
+
+	// Generate server certificate signed by CA
+	if err := generateTestCertSignedByCA(cfg.ServerCertFile, cfg.ServerKeyFile, cfg.CACertFile, cfg.CAKeyFile, true); err != nil {
+		t.Fatalf("failed to generate server certificate: %v", err)
+	}
+
+	// Generate client certificate signed by CA
+	if err := generateTestCertSignedByCA(cfg.ClientCertFile, cfg.ClientKeyFile, cfg.CACertFile, cfg.CAKeyFile, false); err != nil {
+		t.Fatalf("failed to generate client certificate: %v", err)
+	}
+
+	return cfg
+}
+
+func TestValidateCertificateAuthRequiresHTTPS(t *testing.T) {
+	tests := []struct {
+		name      string
+		baseURL   string
+		wantErr   bool
+		errSubstr string
+	}{
+		{
+			name:    "valid https URL",
+			baseURL: "https://example.com",
+			wantErr: false,
+		},
+		{
+			name:      "http URL rejected",
+			baseURL:   "http://example.com",
+			wantErr:   true,
+			errSubstr: "requires HTTPS",
+		},
+		{
+			name:      "empty URL rejected",
+			baseURL:   "",
+			wantErr:   true,
+			errSubstr: "api.base_url is required",
+		},
+		{
+			name:      "invalid URL rejected",
+			baseURL:   "://invalid",
+			wantErr:   true,
+			errSubstr: "invalid api.base_url",
+		},
+		{
+			name:    "https with port",
+			baseURL: "https://example.com:8443",
+			wantErr: false,
+		},
+		{
+			name:    "https with path",
+			baseURL: "https://example.com/api/v1",
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateCertificateAuthRequiresHTTPS(tt.baseURL)
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("expected error containing %q, got nil", tt.errSubstr)
+				} else if !strings.Contains(err.Error(), tt.errSubstr) {
+					t.Errorf("expected error containing %q, got %q", tt.errSubstr, err.Error())
+				}
+			} else if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+func TestValidateCertificateAuth_CAFile(t *testing.T) {
+	certs := setupTestCertificates(t)
+
+	tests := []struct {
+		name      string
+		config    *CertificateAuthConfig
+		wantErr   bool
+		errSubstr string
+	}{
+		{
+			name: "valid with CA file",
+			config: &CertificateAuthConfig{
+				CertFile: certs.ClientCertFile,
+				KeyFile:  certs.ClientKeyFile,
+				CAFile:   certs.CACertFile,
+			},
+			wantErr: false,
+		},
+		{
+			name: "CA file not found",
+			config: &CertificateAuthConfig{
+				CertFile: certs.ClientCertFile,
+				KeyFile:  certs.ClientKeyFile,
+				CAFile:   "/nonexistent/ca.crt",
+			},
+			wantErr:   true,
+			errSubstr: "CA certificate file not found",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateCertificateAuth(tt.config)
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("expected error containing %q, got nil", tt.errSubstr)
+				} else if !strings.Contains(err.Error(), tt.errSubstr) {
+					t.Errorf("expected error containing %q, got %q", tt.errSubstr, err.Error())
+				}
+			} else if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+func TestValidateCertificateAuth_InvalidCAFile(t *testing.T) {
+	certs := setupTestCertificates(t)
+	tempDir := t.TempDir()
+
+	// Create an invalid CA file (not a valid PEM)
+	invalidCAFile := filepath.Join(tempDir, "invalid_ca.crt")
+	if err := os.WriteFile(invalidCAFile, []byte("not a valid certificate"), 0600); err != nil {
+		t.Fatalf("failed to write invalid CA file: %v", err)
+	}
+
+	config := &CertificateAuthConfig{
+		CertFile: certs.ClientCertFile,
+		KeyFile:  certs.ClientKeyFile,
+		CAFile:   invalidCAFile,
+	}
+
+	err := validateCertificateAuth(config)
+	if err == nil {
+		t.Error("expected error for invalid CA file, got nil")
+	}
+	if !strings.Contains(err.Error(), "failed to parse CA certificate") {
+		t.Errorf("expected error about parsing CA certificate, got: %v", err)
+	}
+}
+
+func TestValidateCertificateAuth_InvalidCertKeyPair(t *testing.T) {
+	// Use setupTestCertificates to create two separate CA-signed certificates
+	// so we can test with mismatched cert/key pairs
+	certs1 := setupTestCertificates(t)
+	certs2 := setupTestCertificates(t)
+
+	// Use cert from one pair with key from another
+	config := &CertificateAuthConfig{
+		CertFile: certs1.ClientCertFile,
+		KeyFile:  certs2.ClientKeyFile,
+	}
+
+	err := validateCertificateAuth(config)
+	if err == nil {
+		t.Error("expected error for mismatched cert/key pair, got nil")
+	}
+	if !strings.Contains(err.Error(), "failed to load certificate") {
+		t.Errorf("expected error about loading certificate, got: %v", err)
+	}
+}
+
+func TestApplyCertificateAuth(t *testing.T) {
+	certs := setupTestCertificates(t)
+
+	t.Run("preserves client headers", func(t *testing.T) {
+		// Create a client with custom headers
+		baseClient := NewClient().WithHeader("X-Custom-Header", "custom-value")
+
+		config := &CertificateAuthConfig{
+			CertFile: certs.ClientCertFile,
+			KeyFile:  certs.ClientKeyFile,
+		}
+
+		client, err := applyCertificateAuth(baseClient, config)
+		if err != nil {
+			t.Fatalf("failed to apply certificate auth: %v", err)
+		}
+		if client == nil {
+			t.Fatal("expected non-nil client")
+		}
+
+		// Verify headers are preserved
+		if client.headers.Get("X-Custom-Header") != "custom-value" {
+			t.Error("expected custom header to be preserved")
+		}
+	})
+
+	t.Run("does not modify original client", func(t *testing.T) {
+		baseClient := NewClient()
+		originalHTTPClient := baseClient.httpClient
+
+		config := &CertificateAuthConfig{
+			CertFile: certs.ClientCertFile,
+			KeyFile:  certs.ClientKeyFile,
+		}
+
+		newClient, err := applyCertificateAuth(baseClient, config)
+		if err != nil {
+			t.Fatalf("failed to apply certificate auth: %v", err)
+		}
+
+		// Original client should be unchanged
+		if baseClient.httpClient != originalHTTPClient {
+			t.Error("original client's httpClient should not be modified")
+		}
+
+		// New client should have a different httpClient
+		if newClient.httpClient == originalHTTPClient {
+			t.Error("new client should have a different httpClient with TLS config")
+		}
+	})
+}
+
+func TestCreateCertificateClient(t *testing.T) {
+	certs := setupTestCertificates(t)
+
+	t.Run("creates client with certificate", func(t *testing.T) {
+		config := &CertificateAuthConfig{
+			CertFile: certs.ClientCertFile,
+			KeyFile:  certs.ClientKeyFile,
+		}
+
+		client, err := createCertificateClient(config)
+		if err != nil {
+			t.Fatalf("failed to create certificate client: %v", err)
+		}
+		if client == nil {
+			t.Error("expected non-nil client")
+		}
+	})
+
+	t.Run("creates client with certificate and CA", func(t *testing.T) {
+		config := &CertificateAuthConfig{
+			CertFile: certs.ClientCertFile,
+			KeyFile:  certs.ClientKeyFile,
+			CAFile:   certs.CACertFile,
+		}
+
+		client, err := createCertificateClient(config)
+		if err != nil {
+			t.Fatalf("failed to create certificate client: %v", err)
+		}
+		if client == nil {
+			t.Error("expected non-nil client")
+		}
+	})
+}
+
+func TestGetAuthenticatedClient_Certificate_RequiresHTTPS(t *testing.T) {
+	certs := setupTestCertificates(t)
+
+	viper.Reset()
+	viper.Set("api.base_url", "http://example.com") // HTTP, not HTTPS
+	viper.Set("auth.certificate.cert_file", certs.ClientCertFile)
+	viper.Set("auth.certificate.key_file", certs.ClientKeyFile)
+
+	_, err := GetAuthenticatedClient()
+	if err == nil {
+		t.Error("expected error for HTTP with certificate auth, got nil")
+	}
+	if !strings.Contains(err.Error(), "requires HTTPS") {
+		t.Errorf("expected error about requiring HTTPS, got: %v", err)
+	}
+}
+
+func TestGetAuthenticatedClient_Certificate_AcceptsHTTPS(t *testing.T) {
+	certs := setupTestCertificates(t)
+
+	viper.Reset()
+	viper.Set("api.base_url", "https://example.com")
+	viper.Set("auth.certificate.cert_file", certs.ClientCertFile)
+	viper.Set("auth.certificate.key_file", certs.ClientKeyFile)
+
+	client, err := GetAuthenticatedClient()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if client == nil {
+		t.Error("expected non-nil client")
+	}
+}
+
+// TestCertificateAuth_EndToEnd tests actual mTLS communication.
+// This test creates a TLS server that requires client certificates and verifies
+// that the certificate client can successfully communicate with it.
+func TestCertificateAuth_EndToEnd(t *testing.T) {
+	certs := setupTestCertificates(t)
+
+	// Load CA for server to verify client certificates
+	caCert, err := os.ReadFile(certs.CACertFile)
+	if err != nil {
+		t.Fatalf("failed to read CA certificate: %v", err)
+	}
+	caCertPool := x509.NewCertPool()
+	caCertPool.AppendCertsFromPEM(caCert)
+
+	// Load server certificate
+	serverCert, err := tls.LoadX509KeyPair(certs.ServerCertFile, certs.ServerKeyFile)
+	if err != nil {
+		t.Fatalf("failed to load server certificate: %v", err)
+	}
+
+	// Create TLS server that requires client certificates
+	server := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Verify client certificate was presented
+		if r.TLS == nil || len(r.TLS.PeerCertificates) == 0 {
+			t.Error("expected client certificate to be presented")
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"status":"ok"}`))
+	}))
+	server.TLS = &tls.Config{
+		Certificates: []tls.Certificate{serverCert},
+		ClientCAs:    caCertPool,
+		ClientAuth:   tls.RequireAndVerifyClientCert,
+	}
+	server.StartTLS()
+	defer server.Close()
+
+	// Configure viper with the test server URL
+	viper.Reset()
+	viper.Set("api.base_url", server.URL)
+	viper.Set("auth.certificate.cert_file", certs.ClientCertFile)
+	viper.Set("auth.certificate.key_file", certs.ClientKeyFile)
+	viper.Set("auth.certificate.ca_file", certs.CACertFile)
+
+	// Create authenticated client
+	client, err := GetAuthenticatedClient()
+	if err != nil {
+		t.Fatalf("failed to create authenticated client: %v", err)
+	}
+
+	// Make request to the TLS server
+	var result map[string]string
+	err = client.GetJSON(context.Background(), "/test", &result)
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+
+	if result["status"] != "ok" {
+		t.Errorf("expected status=ok, got %v", result)
+	}
+}
+
+// TestCertificateAuth_EndToEnd_WithoutClientCert verifies that the server
+// rejects requests without client certificates.
+func TestCertificateAuth_EndToEnd_WithoutClientCert(t *testing.T) {
+	certs := setupTestCertificates(t)
+
+	// Load CA for server
+	caCert, err := os.ReadFile(certs.CACertFile)
+	if err != nil {
+		t.Fatalf("failed to read CA certificate: %v", err)
+	}
+	caCertPool := x509.NewCertPool()
+	caCertPool.AppendCertsFromPEM(caCert)
+
+	// Load server certificate
+	serverCert, err := tls.LoadX509KeyPair(certs.ServerCertFile, certs.ServerKeyFile)
+	if err != nil {
+		t.Fatalf("failed to load server certificate: %v", err)
+	}
+
+	// Create TLS server that requires client certificates
+	server := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	server.TLS = &tls.Config{
+		Certificates: []tls.Certificate{serverCert},
+		ClientCAs:    caCertPool,
+		ClientAuth:   tls.RequireAndVerifyClientCert,
+	}
+	server.StartTLS()
+	defer server.Close()
+
+	// Create a client WITHOUT certificate auth
+	httpClient := &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{
+				RootCAs: caCertPool,
+			},
+		},
+	}
+
+	// Request should fail due to missing client certificate
+	_, err = httpClient.Get(server.URL + "/test")
+	if err == nil {
+		t.Error("expected error when connecting without client certificate")
+	}
+}
+
+func TestLoadCACertPool_ValidCA(t *testing.T) {
+	certs := setupTestCertificates(t)
+
+	pool, err := loadCACertPool(certs.CACertFile)
+	if err != nil {
+		t.Fatalf("failed to load CA cert pool: %v", err)
+	}
+	if pool == nil {
+		t.Error("expected non-nil cert pool")
+	}
+}
+
+func TestLoadCACertPool_FileNotFound(t *testing.T) {
+	_, err := loadCACertPool("/nonexistent/ca.crt")
+	if err == nil {
+		t.Error("expected error for nonexistent CA file")
+	}
+	if !strings.Contains(err.Error(), "failed to read CA certificate") {
+		t.Errorf("expected error about reading CA certificate, got: %v", err)
+	}
+}
+
+func TestLoadCACertPool_InvalidPEM(t *testing.T) {
+	tempDir := t.TempDir()
+	invalidCAFile := filepath.Join(tempDir, "invalid_ca.crt")
+	if err := os.WriteFile(invalidCAFile, []byte("not a valid certificate"), 0600); err != nil {
+		t.Fatalf("failed to write invalid CA file: %v", err)
+	}
+
+	_, err := loadCACertPool(invalidCAFile)
+	if err == nil {
+		t.Error("expected error for invalid PEM")
+	}
+	if !strings.Contains(err.Error(), "failed to parse CA certificate") {
+		t.Errorf("expected error about parsing CA certificate, got: %v", err)
+	}
+}

--- a/cmd/utils/httpclient.go
+++ b/cmd/utils/httpclient.go
@@ -157,6 +157,18 @@ func (c *Client) WithBaseBackoff(d time.Duration) *Client {
 	return newClient
 }
 
+// WithHTTPClient returns a new Client using the specified HTTPClient.
+// This is useful for configuring custom transports (e.g., TLS configuration for mTLS).
+// Returns a new Client; does not modify the receiver.
+func (c *Client) WithHTTPClient(httpClient HTTPClient) *Client {
+	return &Client{
+		httpClient:  httpClient,
+		maxRetries:  c.maxRetries,
+		baseBackoff: c.baseBackoff,
+		headers:     copyHeaders(c.headers),
+	}
+}
+
 // applyHeaders copies client-level headers to the request.
 // Does not overwrite headers already set on the request.
 // This preserves request-specific headers like Content-Type.

--- a/cmd/utils/httpclient_test.go
+++ b/cmd/utils/httpclient_test.go
@@ -790,6 +790,46 @@ func TestClient_WithBaseBackoff_Immutable(t *testing.T) {
 	}
 }
 
+func TestClient_WithHTTPClient(t *testing.T) {
+	originalMock := &MockHTTPClient{
+		DoFunc: func(req *http.Request) (*http.Response, error) {
+			return newMockResponse(200, `{}`), nil
+		},
+	}
+	newMock := &MockHTTPClient{
+		DoFunc: func(req *http.Request) (*http.Response, error) {
+			return newMockResponse(201, `{}`), nil
+		},
+	}
+
+	originalClient := NewClientWithHTTPClient(originalMock).
+		WithHeader("X-Custom", "value").
+		WithBaseBackoff(5 * time.Second)
+
+	// Create new client with different HTTP client
+	newClient := originalClient.WithHTTPClient(newMock)
+
+	// Original client should be unchanged
+	if originalClient.httpClient != originalMock {
+		t.Error("Original client's httpClient should not be modified")
+	}
+
+	// New client should have the new HTTP client
+	if newClient.httpClient != newMock {
+		t.Error("New client should have the new httpClient")
+	}
+
+	// New client should preserve headers from original
+	if newClient.headers.Get("X-Custom") != "value" {
+		t.Error("New client should preserve headers from original")
+	}
+
+	// New client should preserve other settings
+	if newClient.baseBackoff != 5*time.Second {
+		t.Error("New client should preserve baseBackoff from original")
+	}
+}
+
 func TestClient_HeadersInPostJSON(t *testing.T) {
 	mockClient := &MockHTTPClient{
 		DoFunc: func(req *http.Request) (*http.Response, error) {


### PR DESCRIPTION
## Summary

- Refactor certificate authentication code from `auth.go` to dedicated `certificate.go` (following OAuth2 pattern)
- Add HTTPS validation when certificate authentication is configured
- Add `WithHTTPClient()` method to Client for consistent builder pattern
- Add comprehensive tests including end-to-end mTLS test with actual TLS server

## Changes

| File | Changes |
|------|---------|
| `cmd/utils/auth.go` | Removed certificate functions (moved to certificate.go), added HTTPS validation call |
| `cmd/utils/httpclient.go` | Added `WithHTTPClient()` method for consistent builder pattern |
| `cmd/utils/httpclient_test.go` | Added test for `WithHTTPClient()` |
| `cmd/utils/certificate.go` | **New** - Certificate auth functions |
| `cmd/utils/certificate_test.go` | **New** - Comprehensive certificate auth tests |

## Acceptance Criteria

- [x] Client certificate is presented during TLS handshake
- [x] Custom CA certificate is used when configured
- [x] Clear error messages for invalid/missing certificate files
- [x] Validation that base_url uses HTTPS when cert auth is configured
- [x] Tests verify TLS configuration is applied

## Test plan

- [x] All existing tests pass
- [x] New certificate validation tests pass
- [x] End-to-end mTLS test verifies actual TLS communication
- [x] HTTPS validation test verifies HTTP URLs are rejected

Closes #25