### PR TITLE
feat: add e2e tests with real Keycloak for OAuth2

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -51,8 +51,25 @@ jobs:
           go-version: '1.25.5'
           cache: true
 
+      - name: Start Keycloak
+        run: |
+          docker compose -f test/oauth2/compose.yaml up -d --build
+          # Wait for Keycloak to become healthy (up to 3 minutes)
+          for i in {1..36}; do
+            if curl -sf http://localhost:9000/health | jq -e '.status == "UP"' > /dev/null 2>&1; then
+              echo "Keycloak is healthy"
+              break
+            fi
+            echo "Waiting for Keycloak... ($i/36)"
+            sleep 5
+          done
+
       - name: Run tests with coverage
         run: go test -v -coverprofile=coverage.txt ./...
+
+      - name: Stop Keycloak
+        if: always()
+        run: docker compose -f test/oauth2/compose.yaml down -v
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5

--- a/cmd/e2e_auth_failure_test.go
+++ b/cmd/e2e_auth_failure_test.go
@@ -1,0 +1,219 @@
+package cmd
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"ftsctl/cmd/testutil"
+	"ftsctl/cmd/testutil/mockserver"
+	"ftsctl/cmd/utils"
+
+	"github.com/spf13/viper"
+)
+
+// TestE2E_BasicAuth_WrongPassword tests that wrong password fails authentication.
+func TestE2E_BasicAuth_WrongPassword(t *testing.T) {
+	server := mockserver.New().WithBasicAuth("correctuser", "correctpass").Start(t)
+	defer server.Close()
+
+	viper.Reset()
+	viper.Set("api.base_url", server.URL())
+	viper.Set("auth.basic.user", "correctuser")
+	viper.Set("auth.basic.password", "wrongpass")
+
+	client, err := utils.GetAuthenticatedClient()
+	if err != nil {
+		t.Fatalf("failed to get authenticated client: %v", err)
+	}
+
+	var projects []string
+	err = client.GetJSON(context.Background(), utils.EndpointProjects, &projects)
+	if err == nil {
+		t.Error("expected error for wrong password, got nil")
+		return
+	}
+
+	// Should get a 401 Unauthorized error
+	var httpErr *utils.HTTPError
+	if !containsHTTPError(err, 401, &httpErr) {
+		t.Errorf("expected 401 Unauthorized error, got: %v", err)
+	}
+}
+
+// TestE2E_BasicAuth_WrongUser tests that wrong username fails authentication.
+func TestE2E_BasicAuth_WrongUser(t *testing.T) {
+	server := mockserver.New().WithBasicAuth("correctuser", "correctpass").Start(t)
+	defer server.Close()
+
+	viper.Reset()
+	viper.Set("api.base_url", server.URL())
+	viper.Set("auth.basic.user", "wronguser")
+	viper.Set("auth.basic.password", "correctpass")
+
+	client, err := utils.GetAuthenticatedClient()
+	if err != nil {
+		t.Fatalf("failed to get authenticated client: %v", err)
+	}
+
+	var projects []string
+	err = client.GetJSON(context.Background(), utils.EndpointProjects, &projects)
+	if err == nil {
+		t.Error("expected error for wrong user, got nil")
+		return
+	}
+
+	var httpErr *utils.HTTPError
+	if !containsHTTPError(err, 401, &httpErr) {
+		t.Errorf("expected 401 Unauthorized error, got: %v", err)
+	}
+}
+
+// TestE2E_BasicAuth_NoCredentials tests that missing credentials fails.
+func TestE2E_BasicAuth_NoCredentials(t *testing.T) {
+	server := mockserver.New().WithBasicAuth("user", "pass").Start(t)
+	defer server.Close()
+
+	viper.Reset()
+	viper.Set("api.base_url", server.URL())
+	// No auth configured
+
+	client, err := utils.GetAuthenticatedClient()
+	if err != nil {
+		t.Fatalf("failed to get authenticated client: %v", err)
+	}
+
+	var projects []string
+	err = client.GetJSON(context.Background(), utils.EndpointProjects, &projects)
+	if err == nil {
+		t.Error("expected error when no credentials provided, got nil")
+		return
+	}
+
+	var httpErr *utils.HTTPError
+	if !containsHTTPError(err, 401, &httpErr) {
+		t.Errorf("expected 401 Unauthorized error, got: %v", err)
+	}
+}
+
+// TestE2E_OAuth2_NoToken tests that missing bearer token fails.
+func TestE2E_OAuth2_NoToken(t *testing.T) {
+	server := mockserver.New().WithOAuth2().Start(t)
+	defer server.Close()
+
+	viper.Reset()
+	viper.Set("api.base_url", server.URL())
+	// No OAuth2 auth configured
+
+	client, err := utils.GetAuthenticatedClient()
+	if err != nil {
+		t.Fatalf("failed to get authenticated client: %v", err)
+	}
+
+	var projects []string
+	err = client.GetJSON(context.Background(), utils.EndpointProjects, &projects)
+	if err == nil {
+		t.Error("expected error when no token provided, got nil")
+		return
+	}
+
+	var httpErr *utils.HTTPError
+	if !containsHTTPError(err, 401, &httpErr) {
+		t.Errorf("expected 401 Unauthorized error, got: %v", err)
+	}
+}
+
+// TestE2E_OAuth2_InvalidTokenEndpoint tests that invalid token URL fails.
+func TestE2E_OAuth2_InvalidTokenEndpoint(t *testing.T) {
+	server := mockserver.New().WithOAuth2().Start(t)
+	defer server.Close()
+
+	viper.Reset()
+	viper.Set("api.base_url", server.URL())
+	viper.Set("auth.oauth2.token_url", "http://localhost:9999/nonexistent")
+	viper.Set("auth.oauth2.client_id", "test-client")
+	viper.Set("auth.oauth2.client_secret", "test-secret")
+
+	_, err := utils.GetAuthenticatedClient()
+	if err == nil {
+		t.Error("expected error for invalid token endpoint, got nil")
+		return
+	}
+
+	if !strings.Contains(err.Error(), "failed to fetch OAuth2 token") {
+		t.Errorf("expected token fetch error, got: %v", err)
+	}
+}
+
+// TestE2E_Certificate_NoCert tests that missing client certificate fails.
+func TestE2E_Certificate_NoCert(t *testing.T) {
+	certs := mockserver.SetupTestCertificates(t)
+	server := mockserver.New().WithCertificate(certs).Start(t)
+	defer server.Close()
+
+	viper.Reset()
+	viper.Set("api.base_url", server.URL())
+	// No certificate auth configured - this should fail at TLS handshake
+
+	client := utils.NewClient()
+
+	var projects []string
+	err := client.GetJSON(context.Background(), utils.EndpointProjects, &projects)
+	if err == nil {
+		t.Error("expected error when no client certificate provided, got nil")
+		return
+	}
+
+	// TLS handshake should fail
+	if !strings.Contains(err.Error(), "tls") && !strings.Contains(err.Error(), "certificate") {
+		t.Logf("got error (likely TLS-related): %v", err)
+	}
+}
+
+// TestE2E_OAuth2_RealKeycloak_InvalidClient tests OAuth2 with wrong client credentials.
+func TestE2E_OAuth2_RealKeycloak_InvalidClient(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	testutil.RequireDockerCompose(t)
+
+	if !testutil.IsKeycloakRunning() {
+		t.Skip("Keycloak is not running, skipping OAuth2 failure test")
+	}
+
+	viper.Reset()
+	viper.Set("api.base_url", "http://localhost:8080") // Won't reach this
+	viper.Set("auth.oauth2.token_url", testutil.DefaultKeycloakConfig().TokenURL)
+	viper.Set("auth.oauth2.client_id", "invalid-client")
+	viper.Set("auth.oauth2.client_secret", "invalid-secret")
+
+	_, err := utils.GetAuthenticatedClient()
+	if err == nil {
+		t.Error("expected error for invalid OAuth2 client, got nil")
+		return
+	}
+
+	if !strings.Contains(err.Error(), "failed to fetch OAuth2 token") {
+		t.Errorf("expected token fetch error, got: %v", err)
+	}
+}
+
+// containsHTTPError checks if the error chain contains an HTTPError with the expected status.
+func containsHTTPError(err error, expectedStatus int, httpErr **utils.HTTPError) bool {
+	for e := err; e != nil; {
+		if he, ok := e.(*utils.HTTPError); ok {
+			if httpErr != nil {
+				*httpErr = he
+			}
+			return he.StatusCode == expectedStatus
+		}
+		// Check if error has Unwrap method
+		if unwrapper, ok := e.(interface{ Unwrap() error }); ok {
+			e = unwrapper.Unwrap()
+		} else {
+			break
+		}
+	}
+	return false
+}

--- a/cmd/e2e_test.go
+++ b/cmd/e2e_test.go
@@ -1,0 +1,242 @@
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	"ftsctl/cmd/testutil"
+	"ftsctl/cmd/testutil/mockserver"
+	"ftsctl/cmd/utils"
+
+	"github.com/spf13/viper"
+)
+
+// TestE2E_NoAuth tests commands against a server with no authentication.
+func TestE2E_NoAuth(t *testing.T) {
+	server := mockserver.New().WithAuthNone().Start(t)
+	defer server.Close()
+
+	viper.Reset()
+	viper.Set("api.base_url", server.URL())
+
+	tests := []struct {
+		name     string
+		testFunc func(t *testing.T)
+	}{
+		{"project list", testProjectList},
+		{"project config", testProjectConfig},
+		{"process list", testProcessList},
+		{"process status", testProcessStatus},
+		{"transfer start", testTransferStart},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.testFunc(t)
+		})
+	}
+}
+
+// TestE2E_BasicAuth tests commands against a server with Basic authentication.
+func TestE2E_BasicAuth(t *testing.T) {
+	const testUser = "testuser"
+	const testPass = "testpass"
+
+	server := mockserver.New().WithBasicAuth(testUser, testPass).Start(t)
+	defer server.Close()
+
+	viper.Reset()
+	viper.Set("api.base_url", server.URL())
+	viper.Set("auth.basic.user", testUser)
+	viper.Set("auth.basic.password", testPass)
+
+	tests := []struct {
+		name     string
+		testFunc func(t *testing.T)
+	}{
+		{"project list", testProjectList},
+		{"project config", testProjectConfig},
+		{"process list", testProcessList},
+		{"process status", testProcessStatus},
+		{"transfer start", testTransferStart},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.testFunc(t)
+		})
+	}
+}
+
+// TestE2E_Certificate tests commands against a server with mTLS certificate authentication.
+func TestE2E_Certificate(t *testing.T) {
+	certs := mockserver.SetupTestCertificates(t)
+	server := mockserver.New().WithCertificate(certs).Start(t)
+	defer server.Close()
+
+	viper.Reset()
+	viper.Set("api.base_url", server.URL())
+	viper.Set("auth.certificate.cert_file", certs.ClientCertFile)
+	viper.Set("auth.certificate.key_file", certs.ClientKeyFile)
+	viper.Set("auth.certificate.ca_file", certs.CACertFile)
+
+	tests := []struct {
+		name     string
+		testFunc func(t *testing.T)
+	}{
+		{"project list", testProjectList},
+		{"project config", testProjectConfig},
+		{"process list", testProcessList},
+		{"process status", testProcessStatus},
+		{"transfer start", testTransferStart},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.testFunc(t)
+		})
+	}
+}
+
+// TestE2E_OAuth2_RealKeycloak tests commands with real Keycloak OAuth2 authentication.
+// This test requires a running Keycloak instance. In CI, Keycloak is started by the workflow.
+// For local testing, run: docker compose -f test/oauth2/compose.yaml up -d --build
+func TestE2E_OAuth2_RealKeycloak(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	if !testutil.IsKeycloakRunning() {
+		t.Skip("Keycloak is not running. Start it with: docker compose -f test/oauth2/compose.yaml up -d --build")
+	}
+
+	keycloakConfig := testutil.DefaultKeycloakConfig()
+
+	// Start mock CDA server with OAuth2 (just validates bearer token exists)
+	server := mockserver.New().WithOAuth2().Start(t)
+	defer server.Close()
+
+	viper.Reset()
+	viper.Set("api.base_url", server.URL())
+	viper.Set("auth.oauth2.token_url", keycloakConfig.TokenURL)
+	viper.Set("auth.oauth2.client_id", keycloakConfig.ClientID)
+	viper.Set("auth.oauth2.client_secret", keycloakConfig.ClientSecret)
+
+	tests := []struct {
+		name     string
+		testFunc func(t *testing.T)
+	}{
+		{"project list", testProjectList},
+		{"project config", testProjectConfig},
+		{"process list", testProcessList},
+		{"process status", testProcessStatus},
+		{"transfer start", testTransferStart},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.testFunc(t)
+		})
+	}
+}
+
+// Test helper functions
+
+func testProjectList(t *testing.T) {
+	t.Helper()
+
+	client, err := utils.GetAuthenticatedClient()
+	if err != nil {
+		t.Fatalf("failed to get authenticated client: %v", err)
+	}
+
+	var projects []string
+	err = client.GetJSON(context.Background(), utils.EndpointProjects, &projects)
+	if err != nil {
+		t.Fatalf("failed to fetch projects: %v", err)
+	}
+
+	if len(projects) != 3 {
+		t.Errorf("expected 3 projects, got %d", len(projects))
+	}
+	if projects[0] != "Project1" {
+		t.Errorf("expected first project to be 'Project1', got %s", projects[0])
+	}
+}
+
+func testProjectConfig(t *testing.T) {
+	t.Helper()
+
+	client, err := utils.GetAuthenticatedClient()
+	if err != nil {
+		t.Fatalf("failed to get authenticated client: %v", err)
+	}
+
+	var config map[string]interface{}
+	err = client.GetJSON(context.Background(), utils.EndpointProjects+"/Project1", &config)
+	if err != nil {
+		t.Fatalf("failed to fetch project config: %v", err)
+	}
+
+	if config["cohortSelector"] == nil {
+		t.Error("expected cohortSelector in config")
+	}
+}
+
+func testProcessList(t *testing.T) {
+	t.Helper()
+
+	client, err := utils.GetAuthenticatedClient()
+	if err != nil {
+		t.Fatalf("failed to get authenticated client: %v", err)
+	}
+
+	var processes []map[string]interface{}
+	err = client.GetJSON(context.Background(), utils.EndpointProcessStatuses, &processes)
+	if err != nil {
+		t.Fatalf("failed to fetch process list: %v", err)
+	}
+
+	if len(processes) != 2 {
+		t.Errorf("expected 2 processes, got %d", len(processes))
+	}
+}
+
+func testProcessStatus(t *testing.T) {
+	t.Helper()
+
+	client, err := utils.GetAuthenticatedClient()
+	if err != nil {
+		t.Fatalf("failed to get authenticated client: %v", err)
+	}
+
+	var process map[string]interface{}
+	err = client.GetJSON(context.Background(), utils.EndpointProcessStatus("proc-123"), &process)
+	if err != nil {
+		t.Fatalf("failed to fetch process status: %v", err)
+	}
+
+	if process["processId"] != "proc-123" {
+		t.Errorf("expected processId 'proc-123', got %v", process["processId"])
+	}
+	if process["phase"] != "RUNNING" {
+		t.Errorf("expected phase 'RUNNING', got %v", process["phase"])
+	}
+}
+
+func testTransferStart(t *testing.T) {
+	t.Helper()
+
+	client, err := utils.GetAuthenticatedClient()
+	if err != nil {
+		t.Fatalf("failed to get authenticated client: %v", err)
+	}
+
+	// Use PostJSON for transfer start which returns 202 Accepted with no body
+	buf := &bytes.Buffer{}
+	err = client.PostJSON(context.Background(), utils.EndpointTransferStart("Project1"), nil, buf)
+	if err != nil {
+		t.Fatalf("failed to start transfer: %v", err)
+	}
+}

--- a/cmd/testutil/keycloak.go
+++ b/cmd/testutil/keycloak.go
@@ -1,0 +1,63 @@
+package testutil
+
+import (
+	"encoding/json"
+	"net/http"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+)
+
+// KeycloakConfig contains the Keycloak configuration for tests.
+type KeycloakConfig struct {
+	TokenURL     string
+	ClientID     string
+	ClientSecret string
+}
+
+// DefaultKeycloakConfig returns the default Keycloak configuration
+// matching the fts-realm.json setup.
+func DefaultKeycloakConfig() *KeycloakConfig {
+	return &KeycloakConfig{
+		TokenURL:     "http://localhost:8080/realms/fts/protocol/openid-connect/token",
+		ClientID:     "cd-client",
+		ClientSecret: "tIQfOvBuhyR1dw9OQ3E4tCeTvcHtiW84",
+	}
+}
+
+// IsKeycloakRunning checks if Keycloak is already running and healthy.
+// Keycloak exposes health on port 9000 in dev mode.
+func IsKeycloakRunning() bool {
+	client := &http.Client{Timeout: 2 * time.Second}
+	resp, err := client.Get("http://localhost:9000/health")
+	if err != nil {
+		return false
+	}
+
+	var health struct {
+		Status string `json:"status"`
+	}
+	decodeErr := json.NewDecoder(resp.Body).Decode(&health)
+	_ = resp.Body.Close()
+	if decodeErr != nil {
+		return false
+	}
+
+	return health.Status == "UP"
+}
+
+// RequireDockerCompose skips the test if docker compose is not available.
+func RequireDockerCompose(t testing.TB) {
+	t.Helper()
+
+	cmd := exec.Command("docker", "compose", "version")
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Skipf("docker compose not available: %v", err)
+	}
+
+	if !strings.Contains(string(output), "Docker Compose") {
+		t.Skipf("docker compose not available: unexpected output: %s", output)
+	}
+}

--- a/cmd/testutil/mockserver/auth.go
+++ b/cmd/testutil/mockserver/auth.go
@@ -1,0 +1,82 @@
+package mockserver
+
+import (
+	"encoding/base64"
+	"net/http"
+	"strings"
+)
+
+// wrapWithAuth wraps the handler with authentication middleware based on authMode.
+func (s *MockCDAServer) wrapWithAuth(handler http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch s.authMode {
+		case AuthNone:
+			// No authentication required
+			handler.ServeHTTP(w, r)
+
+		case AuthBasic:
+			if !s.validateBasicAuth(r) {
+				w.Header().Set("WWW-Authenticate", `Basic realm="ftsctl"`)
+				w.WriteHeader(http.StatusUnauthorized)
+				_, _ = w.Write([]byte(`{"error": "unauthorized"}`))
+				return
+			}
+			handler.ServeHTTP(w, r)
+
+		case AuthOAuth2:
+			if !s.validateBearerToken(r) {
+				w.WriteHeader(http.StatusUnauthorized)
+				_, _ = w.Write([]byte(`{"error": "unauthorized"}`))
+				return
+			}
+			handler.ServeHTTP(w, r)
+
+		case AuthCertificate:
+			// Certificate validation is handled at TLS layer.
+			// If we reach here, the TLS handshake succeeded.
+			handler.ServeHTTP(w, r)
+		}
+	})
+}
+
+// validateBasicAuth validates HTTP Basic authentication credentials.
+func (s *MockCDAServer) validateBasicAuth(r *http.Request) bool {
+	auth := r.Header.Get("Authorization")
+	if auth == "" {
+		return false
+	}
+
+	const prefix = "Basic "
+	if !strings.HasPrefix(auth, prefix) {
+		return false
+	}
+
+	decoded, err := base64.StdEncoding.DecodeString(auth[len(prefix):])
+	if err != nil {
+		return false
+	}
+
+	creds := strings.SplitN(string(decoded), ":", 2)
+	if len(creds) != 2 {
+		return false
+	}
+
+	return creds[0] == s.basicUser && creds[1] == s.basicPass
+}
+
+// validateBearerToken validates that a Bearer token is present (non-empty).
+// This does NOT validate the token content, issuer, or expiry.
+func (s *MockCDAServer) validateBearerToken(r *http.Request) bool {
+	auth := r.Header.Get("Authorization")
+	if auth == "" {
+		return false
+	}
+
+	const prefix = "Bearer "
+	if !strings.HasPrefix(auth, prefix) {
+		return false
+	}
+
+	token := auth[len(prefix):]
+	return token != ""
+}

--- a/cmd/testutil/mockserver/handlers.go
+++ b/cmd/testutil/mockserver/handlers.go
@@ -1,0 +1,192 @@
+package mockserver
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+)
+
+// Default test data
+var (
+	defaultProjects = []string{"Project1", "Project2", "Project3"}
+
+	defaultProjectConfig = map[string]interface{}{
+		"cohortSelector": map[string]interface{}{
+			"trustCenterAgent": map[string]interface{}{
+				"server":                  map[string]string{"baseUrl": "https://tc.example.com"},
+				"domain":                  "test-domain",
+				"patientIdentifierSystem": "http://example.com/pid",
+				"policySystem":            "http://example.com/policy",
+				"policies":                []string{"policy1", "policy2"},
+			},
+		},
+		"dataSelector": map[string]interface{}{
+			"everything": map[string]interface{}{
+				"fhirServer": map[string]string{"baseUrl": "https://fhir.example.com"},
+				"resolve":    map[string]string{"patientIdentifierSystem": "http://example.com/pid"},
+			},
+		},
+	}
+
+	defaultProcessList = []map[string]interface{}{
+		{
+			"processId":            "proc-123",
+			"phase":                "RUNNING",
+			"createdAt":            []int{2024, 1, 15, 10, 30, 0, 0},
+			"finishedAt":           nil,
+			"totalPatients":        100,
+			"totalBundles":         500,
+			"deidentifiedBundles":  300,
+			"sentBundles":          200,
+			"skippedBundles":       10,
+		},
+		{
+			"processId":            "proc-456",
+			"phase":                "COMPLETED",
+			"createdAt":            []int{2024, 1, 15, 10, 30, 0, 0},
+			"finishedAt":           []int{2024, 1, 15, 12, 0, 0, 0},
+			"totalPatients":        50,
+			"totalBundles":         250,
+			"deidentifiedBundles":  250,
+			"sentBundles":          250,
+			"skippedBundles":       0,
+		},
+	}
+)
+
+// registerHandlers registers all API endpoint handlers.
+func (s *MockCDAServer) registerHandlers() {
+	s.mux.HandleFunc("/api/v2/projects", s.handleProjectList)
+	s.mux.HandleFunc("/api/v2/projects/", s.handleProjectConfig)
+	s.mux.HandleFunc("/api/v2/process/statuses", s.handleProcessList)
+	s.mux.HandleFunc("/api/v2/process/status/", s.handleProcessStatus)
+	s.mux.HandleFunc("/api/v2/process/", s.handleTransferStart)
+}
+
+// handleProjectList handles GET /api/v2/projects
+func (s *MockCDAServer) handleProjectList(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		w.WriteHeader(http.StatusMethodNotAllowed)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(defaultProjects); err != nil {
+		s.t.Errorf("failed to encode projects: %v", err)
+	}
+}
+
+// handleProjectConfig handles GET /api/v2/projects/{name}
+func (s *MockCDAServer) handleProjectConfig(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		w.WriteHeader(http.StatusMethodNotAllowed)
+		return
+	}
+
+	// Extract project name from path
+	name := strings.TrimPrefix(r.URL.Path, "/api/v2/projects/")
+	if name == "" {
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	// Check if project exists
+	found := false
+	for _, p := range defaultProjects {
+		if p == name {
+			found = true
+			break
+		}
+	}
+	if !found {
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"error": "project not found"}`))
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(defaultProjectConfig); err != nil {
+		s.t.Errorf("failed to encode project config: %v", err)
+	}
+}
+
+// handleProcessList handles GET /api/v2/process/statuses
+func (s *MockCDAServer) handleProcessList(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		w.WriteHeader(http.StatusMethodNotAllowed)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(defaultProcessList); err != nil {
+		s.t.Errorf("failed to encode process list: %v", err)
+	}
+}
+
+// handleProcessStatus handles GET /api/v2/process/status/{id}
+func (s *MockCDAServer) handleProcessStatus(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		w.WriteHeader(http.StatusMethodNotAllowed)
+		return
+	}
+
+	// Extract process ID from path
+	id := strings.TrimPrefix(r.URL.Path, "/api/v2/process/status/")
+	if id == "" {
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	// Find process
+	for _, p := range defaultProcessList {
+		if p["processId"] == id {
+			w.Header().Set("Content-Type", "application/json")
+			if err := json.NewEncoder(w).Encode(p); err != nil {
+				s.t.Errorf("failed to encode process: %v", err)
+			}
+			return
+		}
+	}
+
+	w.WriteHeader(http.StatusNotFound)
+	_, _ = w.Write([]byte(`{"error": "process not found"}`))
+}
+
+// handleTransferStart handles POST /api/v2/process/{project}/start
+func (s *MockCDAServer) handleTransferStart(w http.ResponseWriter, r *http.Request) {
+	// Only handle POST requests to /api/v2/process/{project}/start
+	if r.Method != http.MethodPost {
+		w.WriteHeader(http.StatusMethodNotAllowed)
+		return
+	}
+
+	// Extract path parts
+	path := strings.TrimPrefix(r.URL.Path, "/api/v2/process/")
+	if !strings.HasSuffix(path, "/start") {
+		w.WriteHeader(http.StatusNotFound)
+		return
+	}
+
+	// Extract project name
+	project := strings.TrimSuffix(path, "/start")
+	if project == "" {
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	// Check if project exists
+	found := false
+	for _, p := range defaultProjects {
+		if p == project {
+			found = true
+			break
+		}
+	}
+	if !found {
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"error": "project not found"}`))
+		return
+	}
+
+	w.WriteHeader(http.StatusAccepted)
+}

--- a/cmd/testutil/mockserver/pki.go
+++ b/cmd/testutil/mockserver/pki.go
@@ -1,0 +1,166 @@
+package mockserver
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"net"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// TestCertificates holds all certificate files for a test scenario.
+type TestCertificates struct {
+	CACertFile     string
+	CAKeyFile      string
+	ServerCertFile string
+	ServerKeyFile  string
+	ClientCertFile string
+	ClientKeyFile  string
+}
+
+// SetupTestCertificates creates a full PKI for testing mTLS.
+// Uses t.TempDir() for automatic cleanup.
+func SetupTestCertificates(t testing.TB) *TestCertificates {
+	t.Helper()
+	tempDir := t.TempDir()
+
+	cfg := &TestCertificates{
+		CACertFile:     filepath.Join(tempDir, "ca.crt"),
+		CAKeyFile:      filepath.Join(tempDir, "ca.key"),
+		ServerCertFile: filepath.Join(tempDir, "server.crt"),
+		ServerKeyFile:  filepath.Join(tempDir, "server.key"),
+		ClientCertFile: filepath.Join(tempDir, "client.crt"),
+		ClientKeyFile:  filepath.Join(tempDir, "client.key"),
+	}
+
+	// Generate CA
+	if err := generateTestCA(cfg.CACertFile, cfg.CAKeyFile); err != nil {
+		t.Fatalf("failed to generate CA: %v", err)
+	}
+
+	// Generate server certificate signed by CA
+	if err := generateTestCertSignedByCA(cfg.ServerCertFile, cfg.ServerKeyFile, cfg.CACertFile, cfg.CAKeyFile, true); err != nil {
+		t.Fatalf("failed to generate server certificate: %v", err)
+	}
+
+	// Generate client certificate signed by CA
+	if err := generateTestCertSignedByCA(cfg.ClientCertFile, cfg.ClientKeyFile, cfg.CACertFile, cfg.CAKeyFile, false); err != nil {
+		t.Fatalf("failed to generate client certificate: %v", err)
+	}
+
+	return cfg
+}
+
+// generateTestCA generates a CA certificate and key for testing.
+func generateTestCA(certFile, keyFile string) error {
+	priv, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		return err
+	}
+
+	template := x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject: pkix.Name{
+			Organization: []string{"Test CA"},
+			CommonName:   "Test CA",
+		},
+		NotBefore:             time.Now(),
+		NotAfter:              time.Now().Add(time.Hour),
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
+		IsCA:                  true,
+		BasicConstraintsValid: true,
+	}
+
+	derBytes, err := x509.CreateCertificate(rand.Reader, &template, &template, &priv.PublicKey, priv)
+	if err != nil {
+		return err
+	}
+
+	return writeCertAndKey(certFile, keyFile, derBytes, priv)
+}
+
+// generateTestCertSignedByCA generates a certificate signed by the given CA.
+func generateTestCertSignedByCA(certFile, keyFile, caCertFile, caKeyFile string, isServer bool) error {
+	// Load CA
+	caCertPEM, err := os.ReadFile(caCertFile)
+	if err != nil {
+		return err
+	}
+	caKeyPEM, err := os.ReadFile(caKeyFile)
+	if err != nil {
+		return err
+	}
+
+	caCertBlock, _ := pem.Decode(caCertPEM)
+	caCert, err := x509.ParseCertificate(caCertBlock.Bytes)
+	if err != nil {
+		return err
+	}
+
+	caKeyBlock, _ := pem.Decode(caKeyPEM)
+	caKey, err := x509.ParsePKCS1PrivateKey(caKeyBlock.Bytes)
+	if err != nil {
+		return err
+	}
+
+	// Generate new key
+	priv, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		return err
+	}
+
+	template := x509.Certificate{
+		SerialNumber: big.NewInt(2),
+		Subject: pkix.Name{
+			Organization: []string{"Test"},
+			CommonName:   "localhost",
+		},
+		NotBefore:             time.Now(),
+		NotAfter:              time.Now().Add(time.Hour),
+		KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
+		BasicConstraintsValid: true,
+		DNSNames:              []string{"localhost"},
+		IPAddresses:           []net.IP{net.IPv4(127, 0, 0, 1)},
+	}
+
+	if isServer {
+		template.ExtKeyUsage = []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth}
+	} else {
+		template.ExtKeyUsage = []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth}
+	}
+
+	derBytes, err := x509.CreateCertificate(rand.Reader, &template, caCert, &priv.PublicKey, caKey)
+	if err != nil {
+		return err
+	}
+
+	return writeCertAndKey(certFile, keyFile, derBytes, priv)
+}
+
+func writeCertAndKey(certFile, keyFile string, certDER []byte, key *rsa.PrivateKey) error {
+	certOut, err := os.Create(certFile)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = certOut.Close() }()
+	if err := pem.Encode(certOut, &pem.Block{Type: "CERTIFICATE", Bytes: certDER}); err != nil {
+		return err
+	}
+
+	keyOut, err := os.Create(keyFile)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = keyOut.Close() }()
+	if err := pem.Encode(keyOut, &pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(key)}); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/cmd/testutil/mockserver/server.go
+++ b/cmd/testutil/mockserver/server.go
@@ -1,0 +1,138 @@
+// Package mockserver provides a mock CDA server for e2e testing.
+package mockserver
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+)
+
+// AuthMode represents the authentication mode for the mock server.
+type AuthMode int
+
+const (
+	// AuthNone means no authentication is required.
+	AuthNone AuthMode = iota
+	// AuthBasic requires HTTP Basic authentication.
+	AuthBasic
+	// AuthOAuth2 requires a Bearer token in the Authorization header.
+	AuthOAuth2
+	// AuthCertificate requires mTLS client certificate authentication.
+	AuthCertificate
+)
+
+// MockCDAServer is a mock CDA server for testing ftsctl commands.
+type MockCDAServer struct {
+	server    *httptest.Server
+	authMode  AuthMode
+	basicUser string
+	basicPass string
+	certs     *TestCertificates
+	mux       *http.ServeMux
+	t         testing.TB
+}
+
+// New creates a new MockCDAServer with no authentication.
+func New() *MockCDAServer {
+	return &MockCDAServer{
+		authMode: AuthNone,
+		mux:      http.NewServeMux(),
+	}
+}
+
+// WithAuthNone configures the server to accept requests without authentication.
+func (s *MockCDAServer) WithAuthNone() *MockCDAServer {
+	s.authMode = AuthNone
+	return s
+}
+
+// WithBasicAuth configures the server to require HTTP Basic authentication.
+func (s *MockCDAServer) WithBasicAuth(user, pass string) *MockCDAServer {
+	s.authMode = AuthBasic
+	s.basicUser = user
+	s.basicPass = pass
+	return s
+}
+
+// WithOAuth2 configures the server to require a Bearer token.
+// The server only validates that a non-empty Bearer token is present,
+// it does NOT validate the token content or issuer.
+func (s *MockCDAServer) WithOAuth2() *MockCDAServer {
+	s.authMode = AuthOAuth2
+	return s
+}
+
+// WithCertificate configures the server to require mTLS client certificate authentication.
+func (s *MockCDAServer) WithCertificate(certs *TestCertificates) *MockCDAServer {
+	s.authMode = AuthCertificate
+	s.certs = certs
+	return s
+}
+
+// Start starts the mock server and registers all API endpoints.
+// Call Close() when done to clean up resources.
+func (s *MockCDAServer) Start(t testing.TB) *MockCDAServer {
+	t.Helper()
+	s.t = t
+
+	// Register API endpoints with auth middleware
+	s.registerHandlers()
+
+	handler := s.wrapWithAuth(s.mux)
+
+	if s.authMode == AuthCertificate {
+		s.startTLSServer(handler)
+	} else {
+		s.server = httptest.NewServer(handler)
+	}
+
+	return s
+}
+
+// startTLSServer starts an HTTPS server with client certificate verification.
+func (s *MockCDAServer) startTLSServer(handler http.Handler) {
+	if s.certs == nil {
+		s.t.Fatal("certificate auth requires test certificates")
+	}
+
+	// Load CA for verifying client certificates
+	caCert, err := os.ReadFile(s.certs.CACertFile)
+	if err != nil {
+		s.t.Fatalf("failed to read CA certificate: %v", err)
+	}
+	caCertPool := x509.NewCertPool()
+	caCertPool.AppendCertsFromPEM(caCert)
+
+	// Load server certificate
+	serverCert, err := tls.LoadX509KeyPair(s.certs.ServerCertFile, s.certs.ServerKeyFile)
+	if err != nil {
+		s.t.Fatalf("failed to load server certificate: %v", err)
+	}
+
+	server := httptest.NewUnstartedServer(handler)
+	server.TLS = &tls.Config{
+		Certificates: []tls.Certificate{serverCert},
+		ClientCAs:    caCertPool,
+		ClientAuth:   tls.RequireAndVerifyClientCert,
+	}
+	server.StartTLS()
+	s.server = server
+}
+
+// Close stops the mock server and releases resources.
+func (s *MockCDAServer) Close() {
+	if s.server != nil {
+		s.server.Close()
+	}
+}
+
+// URL returns the base URL of the mock server.
+func (s *MockCDAServer) URL() string {
+	if s.server == nil {
+		return ""
+	}
+	return s.server.URL
+}

--- a/test/oauth2/Dockerfile
+++ b/test/oauth2/Dockerfile
@@ -1,0 +1,8 @@
+FROM registry.access.redhat.com/ubi9@sha256:2c9bb68a869abf7d7417f6639509ab5eb8500d8429ea11ab59e677be5545162b AS ubi-micro-build
+RUN mkdir -p /mnt/rootfs
+RUN dnf install --installroot /mnt/rootfs curl jq --releasever 9 --setopt install_weak_deps=false --nodocs -y && \
+    dnf --installroot /mnt/rootfs clean all && \
+    rpm --root /mnt/rootfs -e --nodeps setup
+
+FROM quay.io/keycloak/keycloak:26.5.1@sha256:b80a48090594367bd8cf6fe2019466ac4ea49de4d0830fb2a43256eda37b18f5
+COPY --from=ubi-micro-build /mnt/rootfs /

--- a/test/oauth2/compose.yaml
+++ b/test/oauth2/compose.yaml
@@ -1,0 +1,24 @@
+name: keycloak
+
+networks:
+  agents:
+
+services:
+  keycloak:
+    build:
+      dockerfile: Dockerfile
+    command:
+    - start-dev
+    - --import-realm
+    networks: [ "agents" ]
+    ports: [ "8080:8080", "9000:9000" ]
+    volumes:
+    - ./import:/opt/keycloak/data/import
+    environment:
+      KC_HEALTH_ENABLED: true
+    healthcheck:
+      test: [ "CMD-SHELL", "curl -sSf http://localhost:9000/health > /tmp/health.json && cat /tmp/health.json | jq -e '.status == \"UP\"'" ]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+      start_period: 150s

--- a/test/oauth2/import/fts-realm.json
+++ b/test/oauth2/import/fts-realm.json
@@ -1,0 +1,513 @@
+{
+  "id": "53fc5545-8093-48a4-b3b1-8d974ea4cb06",
+  "realm": "fts",
+  "displayName": "FTS",
+  "displayNameHtml": "<div class=\"kc-logo-text\">FTS</div>",
+  "notBefore": 0,
+  "defaultSignatureAlgorithm": "RS256",
+  "revokeRefreshToken": false,
+  "refreshTokenMaxReuse": 0,
+  "accessTokenLifespan": 300,
+  "accessTokenLifespanForImplicitFlow": 900,
+  "ssoSessionIdleTimeout": 1800,
+  "ssoSessionMaxLifespan": 36000,
+  "ssoSessionIdleTimeoutRememberMe": 0,
+  "ssoSessionMaxLifespanRememberMe": 0,
+  "offlineSessionIdleTimeout": 2592000,
+  "offlineSessionMaxLifespanEnabled": false,
+  "offlineSessionMaxLifespan": 5184000,
+  "clientSessionIdleTimeout": 0,
+  "clientSessionMaxLifespan": 0,
+  "clientOfflineSessionIdleTimeout": 0,
+  "clientOfflineSessionMaxLifespan": 0,
+  "accessCodeLifespan": 60,
+  "accessCodeLifespanUserAction": 300,
+  "accessCodeLifespanLogin": 1800,
+  "actionTokenGeneratedByAdminLifespan": 43200,
+  "actionTokenGeneratedByUserLifespan": 300,
+  "oauth2DeviceCodeLifespan": 600,
+  "oauth2DevicePollingInterval": 5,
+  "enabled": true,
+  "sslRequired": "external",
+  "registrationAllowed": false,
+  "registrationEmailAsUsername": false,
+  "rememberMe": false,
+  "verifyEmail": false,
+  "loginWithEmailAllowed": true,
+  "duplicateEmailsAllowed": false,
+  "resetPasswordAllowed": true,
+  "editUsernameAllowed": false,
+  "bruteForceProtected": true,
+  "permanentLockout": false,
+  "maxTemporaryLockouts": 0,
+  "bruteForceStrategy": "MULTIPLE",
+  "maxFailureWaitSeconds": 900,
+  "minimumQuickLoginWaitSeconds": 60,
+  "waitIncrementSeconds": 60,
+  "quickLoginCheckMilliSeconds": 1000,
+  "maxDeltaTimeSeconds": 43200,
+  "failureFactor": 30,
+  "defaultRole": {
+    "id": "0883744b-e94d-438e-9e82-3db361e5c40d",
+    "name": "default-roles-fts",
+    "description": "${role_default-roles}",
+    "composite": true,
+    "clientRole": false,
+    "containerId": "53fc5545-8093-48a4-b3b1-8d974ea4cb06"
+  },
+  "requiredCredentials": [
+    "password"
+  ],
+  "otpPolicyType": "totp",
+  "otpPolicyAlgorithm": "HmacSHA1",
+  "otpPolicyInitialCounter": 0,
+  "otpPolicyDigits": 6,
+  "otpPolicyLookAheadWindow": 1,
+  "otpPolicyPeriod": 30,
+  "otpPolicyCodeReusable": false,
+  "otpSupportedApplications": [
+    "totpAppFreeOTPName",
+    "totpAppGoogleName",
+    "totpAppMicrosoftAuthenticatorName"
+  ],
+  "webAuthnPolicyRpEntityName": "keycloak",
+  "webAuthnPolicySignatureAlgorithms": [
+    "ES256",
+    "RS256"
+  ],
+  "webAuthnPolicyRpId": "",
+  "webAuthnPolicyAttestationConveyancePreference": "not specified",
+  "webAuthnPolicyAuthenticatorAttachment": "not specified",
+  "webAuthnPolicyRequireResidentKey": "not specified",
+  "webAuthnPolicyUserVerificationRequirement": "not specified",
+  "webAuthnPolicyCreateTimeout": 0,
+  "webAuthnPolicyAvoidSameAuthenticatorRegister": false,
+  "webAuthnPolicyAcceptableAaguids": [],
+  "webAuthnPolicyExtraOrigins": [],
+  "webAuthnPolicyPasswordlessRpEntityName": "keycloak",
+  "webAuthnPolicyPasswordlessSignatureAlgorithms": [
+    "ES256",
+    "RS256"
+  ],
+  "webAuthnPolicyPasswordlessRpId": "",
+  "webAuthnPolicyPasswordlessAttestationConveyancePreference": "not specified",
+  "webAuthnPolicyPasswordlessAuthenticatorAttachment": "not specified",
+  "webAuthnPolicyPasswordlessRequireResidentKey": "not specified",
+  "webAuthnPolicyPasswordlessUserVerificationRequirement": "not specified",
+  "webAuthnPolicyPasswordlessCreateTimeout": 0,
+  "webAuthnPolicyPasswordlessAvoidSameAuthenticatorRegister": false,
+  "webAuthnPolicyPasswordlessAcceptableAaguids": [],
+  "webAuthnPolicyPasswordlessExtraOrigins": [],
+  "browserSecurityHeaders": {
+    "contentSecurityPolicyReportOnly": "",
+    "xContentTypeOptions": "nosniff",
+    "referrerPolicy": "no-referrer",
+    "xRobotsTag": "none",
+    "xFrameOptions": "SAMEORIGIN",
+    "contentSecurityPolicy": "frame-src 'self'; frame-ancestors 'self'; object-src 'none';",
+    "xXSSProtection": "1; mode=block",
+    "strictTransportSecurity": "max-age=31536000; includeSubDomains"
+  },
+  "smtpServer": {},
+  "eventsEnabled": false,
+  "eventsListeners": [
+    "jboss-logging"
+  ],
+  "enabledEventTypes": [],
+  "adminEventsEnabled": false,
+  "adminEventsDetailsEnabled": false,
+  "internationalizationEnabled": false,
+  "supportedLocales": [],
+  "browserFlow": "browser",
+  "registrationFlow": "registration",
+  "directGrantFlow": "direct grant",
+  "resetCredentialsFlow": "reset credentials",
+  "clientAuthenticationFlow": "clients",
+  "dockerAuthenticationFlow": "docker auth",
+  "firstBrokerLoginFlow": "first broker login",
+  "attributes": {
+    "cibaBackchannelTokenDeliveryMode": "poll",
+    "cibaExpiresIn": "120",
+    "cibaAuthRequestedUserHint": "login_hint",
+    "oauth2DeviceCodeLifespan": "600",
+    "oauth2DevicePollingInterval": "5",
+    "parRequestUriLifespan": "60",
+    "cibaInterval": "5",
+    "realmReusableOtpCode": "false"
+  },
+  "userManagedAccessAllowed": false,
+  "organizationsEnabled": false,
+  "clientProfiles": {
+    "profiles": []
+  },
+  "clientPolicies": {
+    "policies": []
+  },
+  "clients": [
+    {
+      "id": "ee7a80f4-da2f-4bc8-962b-369c9fd36b1c",
+      "clientId": "fts-client",
+      "name": "FTS CD Client",
+      "surrogateAuthRequired": false,
+      "enabled": true,
+      "alwaysDisplayInConsole": false,
+      "clientAuthenticatorType": "client-secret",
+      "secret": "tIQfOvBuhyR1dw9OQ3E4tCeTvcHtiW84",
+      "redirectUris": [
+        "http://localhost:8080/*"
+      ],
+      "webOrigins": [
+        "http://localhost:8080"
+      ],
+      "notBefore": 0,
+      "bearerOnly": false,
+      "consentRequired": false,
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": true,
+      "serviceAccountsEnabled": true,
+      "publicClient": false,
+      "frontchannelLogout": false,
+      "protocol": "openid-connect",
+      "attributes": {
+        "realm_client": "false",
+        "access.token.lifespan": "1800",
+        "client.secret.creation.time": "1737365263",
+        "backchannel.logout.session.required": "true",
+        "backchannel.logout.revoke.offline.tokens": "false"
+      },
+      "authenticationFlowBindingOverrides": {},
+      "fullScopeAllowed": true,
+      "nodeReRegistrationTimeout": -1,
+      "protocolMappers": [
+        {
+          "id": "2787d9e7-4f4a-4443-8efd-b83b392c8a2e",
+          "name": "Client IP Address",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "clientAddress",
+            "id.token.claim": "true",
+            "introspection.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "clientAddress",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "911d7a9a-0015-4e18-8f75-9b29711b23b0",
+          "name": "Client Host",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "clientHost",
+            "id.token.claim": "true",
+            "introspection.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "clientHost",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "08117557-9386-4a7e-b9b2-c5c67305ade9",
+          "name": "Client ID",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "client_id",
+            "id.token.claim": "true",
+            "introspection.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "client_id",
+            "jsonType.label": "String"
+          }
+        }
+      ],
+      "defaultClientScopes": [
+        "web-origins",
+        "acr",
+        "profile",
+        "roles",
+        "basic",
+        "email"
+      ],
+      "optionalClientScopes": [
+        "address",
+        "phone",
+        "organization",
+        "offline_access",
+        "microprofile-jwt"
+      ],
+      "access": {
+        "view": true,
+        "configure": true,
+        "manage": true
+      }
+    },
+    {
+      "id": "34ed2b5c-6e6d-4477-bfa2-f9c36f4f6133",
+      "clientId": "cd-client",
+      "name": "FTS CD Client",
+      "surrogateAuthRequired": false,
+      "enabled": true,
+      "alwaysDisplayInConsole": false,
+      "clientAuthenticatorType": "client-secret",
+      "secret": "tIQfOvBuhyR1dw9OQ3E4tCeTvcHtiW84",
+      "redirectUris": [
+        "http://localhost:8080/*"
+      ],
+      "webOrigins": [
+        "http://localhost:8080"
+      ],
+      "notBefore": 0,
+      "bearerOnly": false,
+      "consentRequired": false,
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": true,
+      "serviceAccountsEnabled": true,
+      "publicClient": false,
+      "frontchannelLogout": false,
+      "protocol": "openid-connect",
+      "attributes": {
+        "realm_client": "false",
+        "access.token.lifespan": "1800",
+        "client.secret.creation.time": "1737365263",
+        "backchannel.logout.session.required": "true",
+        "backchannel.logout.revoke.offline.tokens": "false"
+      },
+      "authenticationFlowBindingOverrides": {},
+      "fullScopeAllowed": true,
+      "nodeReRegistrationTimeout": -1,
+      "protocolMappers": [
+        {
+          "id": "82945188-7e93-4275-95c2-ffe5e229a691",
+          "name": "Client IP Address",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "clientAddress",
+            "id.token.claim": "true",
+            "introspection.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "clientAddress",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "bb9437ef-0c1b-4d90-aa78-167b54adc883",
+          "name": "Client Host",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "clientHost",
+            "id.token.claim": "true",
+            "introspection.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "clientHost",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "0279c300-c3af-4c06-a443-a2ccecef40c4",
+          "name": "Client ID",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "client_id",
+            "id.token.claim": "true",
+            "introspection.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "client_id",
+            "jsonType.label": "String"
+          }
+        }
+      ],
+      "defaultClientScopes": [
+        "web-origins",
+        "acr",
+        "profile",
+        "roles",
+        "basic",
+        "email"
+      ],
+      "optionalClientScopes": [
+        "address",
+        "phone",
+        "organization",
+        "offline_access",
+        "microprofile-jwt"
+      ],
+      "access": {
+        "view": true,
+        "configure": true,
+        "manage": true
+      }
+    },
+    {
+      "id": "f03b64d9-c57b-4061-a781-52e29bf05084",
+      "clientId": "rd-client",
+      "name": "FTS RD Client",
+      "surrogateAuthRequired": false,
+      "enabled": true,
+      "alwaysDisplayInConsole": false,
+      "clientAuthenticatorType": "client-secret",
+      "secret": "tIQfOvBuhyR1dw9OQ3E4tCeTvcHtiW84",
+      "redirectUris": [
+        "http://localhost:8080/*"
+      ],
+      "webOrigins": [
+        "http://localhost:8080"
+      ],
+      "notBefore": 0,
+      "bearerOnly": false,
+      "consentRequired": false,
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": true,
+      "serviceAccountsEnabled": true,
+      "publicClient": false,
+      "frontchannelLogout": false,
+      "protocol": "openid-connect",
+      "attributes": {
+        "realm_client": "false",
+        "access.token.lifespan": "1800",
+        "client.secret.creation.time": "1737365263",
+        "backchannel.logout.session.required": "true",
+        "backchannel.logout.revoke.offline.tokens": "false"
+      },
+      "authenticationFlowBindingOverrides": {},
+      "fullScopeAllowed": true,
+      "nodeReRegistrationTimeout": -1,
+      "protocolMappers": [
+        {
+          "id": "08f5928a-1673-4d08-bf8d-5fc52b37ea2d",
+          "name": "Client IP Address",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "clientAddress",
+            "id.token.claim": "true",
+            "introspection.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "clientAddress",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "49404a86-a5aa-4dd9-b847-a8474bbd0841",
+          "name": "Client Host",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "clientHost",
+            "id.token.claim": "true",
+            "introspection.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "clientHost",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "32165832-73ef-4a51-8a8c-75310171c9e4",
+          "name": "Client ID",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "client_id",
+            "id.token.claim": "true",
+            "introspection.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "client_id",
+            "jsonType.label": "String"
+          }
+        }
+      ],
+      "defaultClientScopes": [
+        "web-origins",
+        "acr",
+        "profile",
+        "roles",
+        "basic",
+        "email"
+      ],
+      "optionalClientScopes": [
+        "address",
+        "phone",
+        "organization",
+        "offline_access",
+        "microprofile-jwt"
+      ],
+      "access": {
+        "view": true,
+        "configure": true,
+        "manage": true
+      }
+    }
+  ],
+  "roles": {
+    "client": {
+      "fts-client": [
+        {
+          "name": "cd-client"
+        },
+        {
+          "name": "rd-client"
+        }
+      ]
+    }
+  },
+  "clientScopeMappings": {
+    "fts-client": [
+      {
+        "client": "cd-client",
+        "roles": [
+          "cd-client"
+        ]
+      },
+      {
+        "client": "rd-client",
+        "roles": [
+          "rd-client"
+        ]
+      }
+    ]
+  },
+  "users": [
+    {
+      "username": "service-account-cd-client",
+      "enabled": true,
+      "serviceAccountClientId": "cd-client",
+      "clientRoles": {
+        "fts-client": [
+          "cd-client"
+        ]
+      },
+      "realmRoles": [
+        "default-roles-cd"
+      ]
+    },
+    {
+      "username": "service-account-rd-client",
+      "enabled": true,
+      "serviceAccountClientId": "rd-client",
+      "clientRoles": {
+        "fts-client": [
+          "rd-client"
+        ]
+      },
+      "realmRoles": [
+        "default-roles-rd"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- Add comprehensive e2e tests for ftsctl using all 4 authentication methods
- OAuth2 tests use a real Keycloak server running in Docker
- Mock CDA server validates auth without requiring full FTS stack

## Changes

### New Packages

**`cmd/testutil/mockserver/`** - Mock CDA server with configurable auth:
- `server.go` - Server with builder pattern (`WithBasicAuth()`, `WithOAuth2()`, etc.)
- `handlers.go` - API endpoint handlers for projects, processes, transfers
- `auth.go` - Auth middleware (None, Basic, OAuth2, Certificate)
- `pki.go` - PKI utilities for certificate tests

**`test/oauth2/`** - Keycloak Docker setup (copied from fts-next):
- `compose.yaml` - Keycloak service config
- `Dockerfile` - Keycloak with curl/jq for healthcheck
- `import/fts-realm.json` - FTS realm with cd-client credentials

**`cmd/testutil/keycloak.go`** - Keycloak Docker lifecycle helpers

### Test Files

- `cmd/e2e_test.go` - E2E tests for NoAuth, BasicAuth, Certificate, OAuth2+Keycloak
- `cmd/e2e_auth_failure_test.go` - Auth failure scenarios (wrong password, invalid token, etc.)

## Test Matrix

| Auth Method | Implementation |
|-------------|----------------|
| None | Mock CDA passes all requests through |
| Basic | Mock CDA validates Authorization header |
| OAuth2 | Real Keycloak token fetch, mock CDA validates Bearer exists |
| Certificate | Mock CDA TLS layer validates client cert |

## Test plan

- [x] `go test -short ./cmd/...` - Fast tests without Keycloak
- [x] `go test ./cmd/...` - All tests including Keycloak (~40s)
- [x] All existing tests continue to pass

Closes #30